### PR TITLE
fix: detect void of course moon correctly when aspect orb exceeds traditional limit

### DIFF
--- a/src/utils/horary/voidOfCourseMoon.ts
+++ b/src/utils/horary/voidOfCourseMoon.ts
@@ -117,7 +117,9 @@ function willMoonMakeAspect(
     // Calculate orb from exact aspect
     const currentOrb = Math.abs(currentSepNormalized - aspect.angle);
 
-    if (currentOrb > MOON_ORB) continue; // Not within orb, skip
+    // Do NOT skip based on current orb — the Moon can pick up aspects outside
+    // traditional orb as it travels through the rest of its sign. The sign-change
+    // timing check below (timeToExact < timeToSignChange) is the correct gate.
 
     // Calculate the relative speed (Moon's motion relative to planet)
     const relativeSpeed = moonSpeed - planetSpeed; // degrees per day


### PR DESCRIPTION
The Moon at 4.30° Leo was incorrectly flagged as void of course. It will
perfect an opposition with Mars (28.47° Aquarius) at ~29.43° Leo/Aquarius
in ~1.9 days — before either planet changes signs (~1.95 days and ~2.2 days
respectively).

The bug was in `willMoonMakeAspect`: an early-exit check skipped any aspect
whose current orb exceeded MOON_ORB (12°). The Moon-Mars opposition had a
current orb of ~24°, so it was never evaluated. For void of course purposes,
traditional orb limits do not apply — what matters is whether the Moon will
reach exactness with any planet before leaving its sign. The existing
`timeToExact < timeToSignChange` guard already prevents false positives, so
the upfront orb cutoff was both unnecessary and incorrect.

https://claude.ai/code/session_01QUncqLuJ6mAJoEV3WDciKj