### PR TITLE
Fix Mercury glyph (crown removed by mistake) and improve mobile glyph scale

### DIFF
--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -87,9 +87,13 @@ const renderChart = async (data: QuestionData) => {
     const chartSize = Math.min(containerWidth - 40, 800);
     console.log('Calculated chart size:', chartSize);
 
+    // Scale up glyphs on small charts so they remain legible on mobile
+    const symbolScale = chartSize < 350 ? 1.5 : chartSize < 500 ? 1.2 : 1;
+
     // Create new chart within our container
     const radix = new Chart("paper", chartSize, chartSize, {
       DEBUG: false,
+      SYMBOL_SCALE: symbolScale,
       SYMBOL_SUN: "sun",
       SYMBOL_MOON: "moon",
       SYMBOL_MERCURY: "mercury",
@@ -160,20 +164,6 @@ const fixRetrogradeSymbols = (planets: any) => {
         }
       }
 
-      // Handle Mercury's extra path (it has 2 paths when retrograde)
-      if (planetKey === 'mercury' && planetGroup.children.length > 1) {
-        if (!planetData.isRetrograde) {
-          // Remove the second path (the retrograde indicator)
-          planetGroup.children[1]?.remove();
-        } else {
-          // Make the retrograde path red
-          const rxPath = planetGroup.children[1] as SVGPathElement;
-          if (rxPath) {
-            rxPath.setAttribute('stroke', '#dc2626');
-            rxPath.setAttribute('fill', '#dc2626');
-          }
-        }
-      }
     }
   });
 };


### PR DESCRIPTION
The astrochart library's mercury() always renders 2 SVG paths — a body
(circle + cross) and a crown (crescent arc) — regardless of retrograde
state. The previous fixRetrogradeSymbols() code incorrectly assumed the
second path was a retrograde indicator and removed it when Mercury was
direct, stripping the crown that visually distinguishes Mercury from Venus.

Remove that erroneous block entirely. Retrograde state for all planets,
including Mercury, is already handled correctly via the text-sibling logic
(the library signals retrograde with an "R" text element, not an extra path).

Also introduce a responsive SYMBOL_SCALE: glyphs scale to 1.5× on charts
narrower than 350 px and 1.2× below 500 px, making planet symbols legible
on mobile without requiring a larger chart canvas.

https://claude.ai/code/session_01QyoPrK9eRZcmrPwupRZXs8