### PR TITLE
Fix regression: remove SYMBOL_SCALE, fill chart via CSS viewBox scaling

### DIFF
--- a/src/components/HoraryChart.vue
+++ b/src/components/HoraryChart.vue
@@ -60,10 +60,14 @@ const props = defineProps<ChartProps>();
   position: relative;
 }
 
-/* Ensure the chart SVG is contained and responsive */
+/* Force the SVG to fill the paper container.
+   The library sets fixed pixel width/height on the SVG, but it also
+   adds a matching viewBox, so overriding the dimensions via CSS causes
+   the browser to scale the entire chart proportionally — no clipping. */
 .chart-paper :deep(svg) {
-  max-width: 100%;
-  max-height: 100%;
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
 }
 
 @media (max-width: 768px) {

--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -87,13 +87,9 @@ const renderChart = async (data: QuestionData) => {
     const chartSize = Math.min(containerWidth - 40, 800);
     console.log('Calculated chart size:', chartSize);
 
-    // Scale up glyphs on small charts so they remain legible on mobile
-    const symbolScale = chartSize < 350 ? 1.5 : chartSize < 500 ? 1.2 : 1;
-
     // Create new chart within our container
     const radix = new Chart("paper", chartSize, chartSize, {
       DEBUG: false,
-      SYMBOL_SCALE: symbolScale,
       SYMBOL_SUN: "sun",
       SYMBOL_MOON: "moon",
       SYMBOL_MERCURY: "mercury",


### PR DESCRIPTION
SYMBOL_SCALE: 1.5 shrank the planet-ring radius by PADDING×0.5=9px, causing planet placement to fail on small mobile charts (glyphs and aspects disappeared, leaving only the outer zodiac wheel).

Revert to the library's default SYMBOL_SCALE (1) by removing it from the Chart constructor options entirely.

Fix mobile chart size correctly: the astrochart library already writes a viewBox matching its render dimensions onto the SVG element. Setting width/height to 100% via CSS therefore triggers proportional scaling rather than cropping, making the chart fill the .chart-paper container (width:100%; aspect-ratio:1/1) on every screen size — no JS measurement tricks or library internals required.

https://claude.ai/code/session_01QyoPrK9eRZcmrPwupRZXs8