### PR TITLE
Make chart fill the viewport rather than a bordered container

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -169,12 +169,11 @@ body {
 
 /* App container */
 .app-container {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 100vw;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 /* Header */
@@ -309,6 +308,7 @@ body {
 /* Main content */
 .app-main {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   max-width: 1200px;
@@ -316,7 +316,7 @@ body {
   width: 100%;
   padding: 1rem;
   gap: 1rem;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 /* Tablet optimizations */

--- a/src/components/HoraryChart.vue
+++ b/src/components/HoraryChart.vue
@@ -25,77 +25,34 @@ const props = defineProps<ChartProps>();
 </template>
 
 <style scoped>
+/* No card wrapper — the chart wheel is self-contained visually. */
 .chart-container {
-  background: var(--color-bg-secondary);
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: var(--shadow-md);
-  width: 100%;
-  overflow: hidden;
-  transition: background-color 0.3s ease;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
+/* Container-query context so chart-paper can fill the shorter side. */
 .chart-content {
-  min-height: 300px;
-  border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
-  padding: 0.25rem;
+  flex: 1;
+  min-height: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
-  width: 100%;
-  overflow: hidden;
-  background: var(--color-bg-secondary);
+  container-type: size;
 }
 
+/* Square that fills whichever dimension is smaller. */
 .chart-paper {
-  width: 100%;
-  height: auto;
-  max-width: 800px;
-  aspect-ratio: 1/1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
+  width: min(100cqw, 100cqh);
+  height: min(100cqw, 100cqh);
 }
 
-/* Force the SVG to fill the paper container.
-   The library sets fixed pixel width/height on the SVG, but it also
-   adds a matching viewBox, so overriding the dimensions via CSS causes
-   the browser to scale the entire chart proportionally — no clipping. */
+/* SVG fills the paper square; viewBox handles internal scaling. */
 .chart-paper :deep(svg) {
   width: 100% !important;
   height: 100% !important;
   display: block;
-}
-
-@media (max-width: 768px) {
-  .chart-container {
-    padding: 0.5rem;
-  }
-
-  .chart-content {
-    min-height: auto;
-    padding: 0.25rem;
-    border: none;
-  }
-
-  .chart-paper {
-    max-width: 100%;
-    width: 100%;
-  }
-}
-
-@media (max-width: 640px) {
-  .chart-container {
-    padding: 0.5rem;
-    background: transparent;
-    box-shadow: none;
-  }
-
-  .chart-content {
-    padding: 0.25rem;
-  }
 }
 </style>

--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -80,12 +80,8 @@ const renderChart = async (data: QuestionData) => {
       ),
     };
 
-    // Calculate responsive chart size
-    const containerWidth = paper.parentElement?.clientWidth || 600;
-    console.log('Chart container width:', containerWidth);
-    // Larger on desktop (up to 800px), responsive on mobile
-    const chartSize = Math.min(containerWidth - 40, 800);
-    console.log('Calculated chart size:', chartSize);
+    // Render at a fixed resolution; CSS scales the SVG to fill the container.
+    const chartSize = 800;
 
     // Create new chart within our container
     const radix = new Chart("paper", chartSize, chartSize, {
@@ -368,18 +364,20 @@ watch(activeTab, async (newTab) => {
 .user-chat {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   width: 100%;
-  height: 100%;
+  overflow-y: auto;
 }
 
 .content-area {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 1rem;
   background: var(--color-bg-secondary);
   border-radius: 1rem;
   box-shadow: var(--shadow-md);
-  min-height: 300px;
   width: 100%;
   overflow-x: hidden;
   transition: background-color 0.3s ease;
@@ -508,14 +506,15 @@ watch(activeTab, async (newTab) => {
   display: grid;
   grid-template-columns: 2fr 1fr;
   gap: 1.5rem;
-  height: 100%;
+  min-height: 100%;
 }
 
 .chart-section {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-width: 0; /* Prevent overflow */
+  min-width: 0;
+  min-height: 0;
 }
 
 .chart-actions {
@@ -598,7 +597,9 @@ watch(activeTab, async (newTab) => {
 }
 
 .tab-content {
-  min-height: 400px;
+  flex: 1;
+  min-height: 300px;
+  overflow: hidden;
 }
 
 .input-area {

--- a/src/style.css
+++ b/src/style.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -59,10 +57,9 @@ button:focus-visible {
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
- Remove Vite template defaults (body flex-centering, #app padding/max-width) that were silently eating ~64px of available width
- Thread a proper height chain from html → #app → .app-container → .app-main → .user-chat → .content-area → .tab-content → HoraryChart using flex: 1 / min-height: 0 at each level
- Replace HoraryChart card boxes (bg, border, padding, shadow) with a plain container that fills its column; use container queries (min(100cqw, 100cqh)) so the wheel is always a square filling the shorter dimension without overflow
- Render chart SVG at a fixed 800×800 resolution; CSS handles all scaling, so the library always has room for crisp glyphs

https://claude.ai/code/session_01QyoPrK9eRZcmrPwupRZXs8