### PR TITLE
Fix dark mode across chat, chart data, reading history, and question form

### DIFF
--- a/src/components/ChartDataView.vue
+++ b/src/components/ChartDataView.vue
@@ -698,7 +698,7 @@ const formatTimeToExact = (days: number | undefined) => {
   background: var(--color-bg-secondary);
   border-radius: 0.5rem;
   padding: 1rem;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--color-border);
 }
 
 .aspect-description {
@@ -709,7 +709,7 @@ const formatTimeToExact = (days: number | undefined) => {
 
 .aspect-description strong {
   text-transform: capitalize;
-  color: #1f2937;
+  color: var(--color-text-primary);
 }
 
 .aspect-details {
@@ -1377,5 +1377,146 @@ const formatTimeToExact = (days: number | undefined) => {
     font-size: 0.7rem;
     padding: 0.2rem 0.5rem;
   }
+}
+
+/* Dark mode overrides for colored status badges */
+:global(.dark) .rx-badge {
+  background: rgba(220, 38, 38, 0.25);
+  color: #fca5a5;
+}
+
+:global(.dark) .direct-badge {
+  color: #6ee7b7;
+}
+
+:global(.dark) .retrograde {
+  background: rgba(220, 38, 38, 0.1);
+}
+
+:global(.dark) .moon-section {
+  background: rgba(251, 191, 36, 0.1);
+  border-color: #d97706;
+}
+
+:global(.dark) .motion.applying {
+  background: rgba(16, 185, 129, 0.2);
+  color: #6ee7b7;
+}
+
+:global(.dark) .motion.separating {
+  background: rgba(59, 130, 246, 0.2);
+  color: #93c5fd;
+}
+
+:global(.dark) .faded-badge {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fcd34d;
+}
+
+:global(.dark) .applying-badge {
+  background: rgba(16, 185, 129, 0.2);
+  color: #6ee7b7;
+}
+
+:global(.dark) .separating-badge {
+  background: rgba(59, 130, 246, 0.2);
+  color: #93c5fd;
+}
+
+:global(.dark) .stable-badge {
+  background: rgba(107, 114, 128, 0.3);
+  color: var(--color-text-secondary);
+}
+
+:global(.dark) .moon-aspect {
+  background: rgba(251, 191, 36, 0.1);
+}
+
+:global(.dark) .copy-btn.copied {
+  background: rgba(16, 185, 129, 0.2);
+  color: #6ee7b7;
+}
+
+:global(.dark) .house-badge.angular {
+  background: rgba(34, 197, 94, 0.2);
+  color: #86efac;
+}
+
+:global(.dark) .house-badge.succedent {
+  background: rgba(59, 130, 246, 0.2);
+  color: #93c5fd;
+}
+
+:global(.dark) .house-badge.cadent {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fcd34d;
+}
+
+:global(.dark) .speed-badge.swift {
+  background: rgba(16, 185, 129, 0.2);
+  color: #6ee7b7;
+}
+
+:global(.dark) .speed-badge.average {
+  background: rgba(107, 114, 128, 0.2);
+  color: #d1d5db;
+}
+
+:global(.dark) .speed-badge.slow {
+  background: rgba(249, 115, 22, 0.2);
+  color: #fdba74;
+}
+
+:global(.dark) .speed-badge.retrograde {
+  background: rgba(220, 38, 38, 0.2);
+  color: #fca5a5;
+}
+
+:global(.dark) .light-badge.cazimi {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fcd34d;
+  border-color: #b45309;
+}
+
+:global(.dark) .light-badge.in-chariot {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fde68a;
+  border-color: #d97706;
+}
+
+:global(.dark) .light-badge.combust {
+  background: rgba(220, 38, 38, 0.2);
+  color: #fca5a5;
+}
+
+:global(.dark) .light-badge.under-beams {
+  background: rgba(249, 115, 22, 0.2);
+  color: #fdba74;
+}
+
+:global(.dark) .light-badge.free {
+  background: rgba(16, 185, 129, 0.2);
+  color: #6ee7b7;
+}
+
+:global(.dark) .light-badge.na {
+  background: rgba(107, 114, 128, 0.2);
+  color: #9ca3af;
+}
+
+:global(.dark) .no-aspect {
+  color: var(--color-text-tertiary);
+}
+
+:global(.dark) .past-time {
+  color: var(--color-text-tertiary);
+}
+
+:global(.dark) .dignity-score.positive {
+  color: #34d399;
+}
+
+:global(.dark) .dignity-score.negative {
+  color: #f87171;
 }
 </style>

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -282,7 +282,7 @@ watch(() => props.reading, (newReading) => {
   flex-direction: column;
   height: 100%;
   max-height: 80vh;
-  background: white;
+  background: var(--color-bg-secondary);
   border-radius: 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   overflow: hidden;
@@ -290,25 +290,25 @@ watch(() => props.reading, (newReading) => {
 
 .conversation-header {
   padding: 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
-  background: #f8fafc;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
 }
 
 .conversation-header h3 {
   margin: 0 0 0.5rem 0;
-  color: #2c3e50;
+  color: var(--color-text-primary);
   font-size: 1.25rem;
 }
 
 .question-info .question {
   font-style: italic;
-  color: #4a5568;
+  color: var(--color-text-secondary);
   margin: 0.5rem 0;
   font-size: 1rem;
 }
 
 .question-info .meta {
-  color: #718096;
+  color: var(--color-text-tertiary);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -401,7 +401,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message.assistant .message-text :deep(blockquote) {
-  border-left-color: rgba(0, 0, 0, 0.15);
+  border-left-color: var(--color-border);
 }
 
 .message.user .message-text :deep(blockquote) {
@@ -416,7 +416,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message.assistant .message-text :deep(code) {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(128, 128, 128, 0.15);
 }
 
 .message.user .message-text :deep(code) {
@@ -431,7 +431,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message.assistant .message-text :deep(pre) {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(128, 128, 128, 0.15);
 }
 
 .message.user .message-text :deep(pre) {
@@ -458,21 +458,21 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message.assistant .message-text {
-  background: #f1f5f9;
-  color: #2c3e50;
-  border: 1px solid #e2e8f0;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
   border-bottom-left-radius: 0.25rem;
 }
 
 .message.error-message .message-text {
-  background: #fef2f2;
-  border-color: #fecaca;
-  color: #991b1b;
+  background: rgba(220, 38, 38, 0.15);
+  border-color: rgba(220, 38, 38, 0.3);
+  color: var(--color-error);
 }
 
 .message-time {
   font-size: 0.75rem;
-  color: #718096;
+  color: var(--color-text-tertiary);
   margin-top: 0.25rem;
   align-self: flex-end;
 }
@@ -486,8 +486,8 @@ watch(() => props.reading, (newReading) => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
   border-radius: 1rem;
   border-bottom-left-radius: 0.25rem;
 }
@@ -524,14 +524,14 @@ watch(() => props.reading, (newReading) => {
 }
 
 .loading-text {
-  color: #4a5568;
+  color: var(--color-text-secondary);
   font-size: 0.875rem;
 }
 
 .conversation-input {
   padding: 1rem;
-  border-top: 1px solid #e2e8f0;
-  background: white;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
 }
 
 .input-container {
@@ -543,7 +543,7 @@ watch(() => props.reading, (newReading) => {
 .message-input {
   flex: 1;
   padding: 0.75rem;
-  border: 2px solid #e2e8f0;
+  border: 2px solid var(--color-border);
   border-radius: 0.5rem;
   font-size: 1rem;
   resize: none;
@@ -551,16 +551,18 @@ watch(() => props.reading, (newReading) => {
   max-height: 120px;
   overflow-y: auto;
   transition: border-color 0.2s ease;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
 }
 
 .message-input:focus {
   outline: none;
-  border-color: #4a90e2;
+  border-color: var(--color-accent);
 }
 
 .message-input:disabled {
-  background: #f7fafc;
-  color: #a0aec0;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-tertiary);
 }
 
 .send-button {
@@ -583,7 +585,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .send-button:disabled {
-  background: #cbd5e0;
+  background: var(--color-bg-hover);
   cursor: not-allowed;
 }
 

--- a/src/components/HoraryChart.vue
+++ b/src/components/HoraryChart.vue
@@ -55,4 +55,9 @@ const props = defineProps<ChartProps>();
   height: 100% !important;
   display: block;
 }
+
+/* Invert the chart SVG in dark mode so it's readable on dark backgrounds */
+:global(.dark) .chart-paper :deep(svg) {
+  filter: invert(1) hue-rotate(180deg);
+}
 </style>

--- a/src/components/QuestionForm.vue
+++ b/src/components/QuestionForm.vue
@@ -222,7 +222,7 @@ onMounted(() => {
 <style scoped>
 .question-form-container {
   width: 100%;
-  background: white;
+  background: var(--color-bg-secondary);
   border-radius: 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s ease;
@@ -249,7 +249,7 @@ onMounted(() => {
 textarea {
   width: 100%;
   padding: 0.75rem;
-  border: 2px solid #e2e8f0;
+  border: 2px solid var(--color-border);
   border-radius: 0.5rem;
   font-size: 1rem;
   resize: none;
@@ -257,11 +257,13 @@ textarea {
   min-height: 44px;
   max-height: 120px;
   overflow-y: auto;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
 }
 
 textarea:focus {
   outline: none;
-  border-color: #4a90e2;
+  border-color: var(--color-accent);
 }
 
 textarea.error {
@@ -300,7 +302,8 @@ textarea.error {
 }
 
 .submit-button:disabled {
-  background-color: #cbd5e0;
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-tertiary);
   cursor: not-allowed;
 }
 

--- a/src/components/ReadingHistory.vue
+++ b/src/components/ReadingHistory.vue
@@ -229,15 +229,15 @@ onMounted(loadReadings);
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: white;
+  background: var(--color-bg-secondary);
   border-radius: 1rem;
   overflow: hidden;
 }
 
 .history-header {
   padding: 1.5rem;
-  border-bottom: 1px solid #e2e8f0;
-  background: #f8fafc;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
 }
 
 .header-top {
@@ -249,7 +249,7 @@ onMounted(loadReadings);
 
 .header-top h2 {
   margin: 0;
-  color: #2c3e50;
+  color: var(--color-text-primary);
 }
 
 .close-button {
@@ -257,7 +257,7 @@ onMounted(loadReadings);
   border: none;
   padding: 0.5rem;
   cursor: pointer;
-  color: #6b7280;
+  color: var(--color-text-secondary);
   border-radius: 0.5rem;
   transition: background-color 0.2s;
   min-width: 44px;
@@ -265,7 +265,7 @@ onMounted(loadReadings);
 }
 
 .close-button:hover {
-  background: #e5e7eb;
+  background: var(--color-bg-hover);
 }
 
 .search-bar {
@@ -275,22 +275,24 @@ onMounted(loadReadings);
 .search-input {
   width: 100%;
   padding: 0.75rem;
-  border: 2px solid #e2e8f0;
+  border: 2px solid var(--color-border);
   border-radius: 0.5rem;
   font-size: 1rem;
   transition: border-color 0.2s;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
 }
 
 .search-input:focus {
   outline: none;
-  border-color: #4a90e2;
+  border-color: var(--color-accent);
 }
 
 .stats {
   display: flex;
   gap: 1rem;
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 .history-content {
@@ -302,13 +304,13 @@ onMounted(loadReadings);
 .loading {
   text-align: center;
   padding: 2rem;
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 .empty-state {
   text-align: center;
   padding: 3rem 1rem;
-  color: #6b7280;
+  color: var(--color-text-secondary);
 }
 
 .empty-icon {
@@ -318,7 +320,7 @@ onMounted(loadReadings);
 
 .empty-state h3 {
   margin: 0 0 0.5rem 0;
-  color: #374151;
+  color: var(--color-text-primary);
 }
 
 .date-group {
@@ -326,12 +328,12 @@ onMounted(loadReadings);
 }
 
 .date-header {
-  color: #4a5568;
+  color: var(--color-text-secondary);
   font-size: 1rem;
   font-weight: 600;
   margin: 0 0 1rem 0;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .readings-grid {
@@ -341,8 +343,8 @@ onMounted(loadReadings);
 }
 
 .reading-card {
-  background: white;
-  border: 1px solid #e2e8f0;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   padding: 1rem;
   cursor: pointer;
@@ -363,7 +365,7 @@ onMounted(loadReadings);
 
 .reading-time {
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--color-text-tertiary);
   font-weight: 500;
 }
 
@@ -372,7 +374,7 @@ onMounted(loadReadings);
   border: none;
   padding: 0.5rem;
   cursor: pointer;
-  color: #6b7280;
+  color: var(--color-text-secondary);
   border-radius: 0.25rem;
   transition: color 0.2s;
   min-width: 44px;
@@ -385,7 +387,7 @@ onMounted(loadReadings);
 
 .reading-question {
   font-size: 1rem;
-  color: #2c3e50;
+  color: var(--color-text-primary);
   line-height: 1.4;
   margin-bottom: 0.75rem;
 }
@@ -394,12 +396,12 @@ onMounted(loadReadings);
   display: flex;
   gap: 1rem;
   font-size: 0.75rem;
-  color: #6b7280;
+  color: var(--color-text-tertiary);
 }
 
 .conversation-count {
-  background: #ddd6fe;
-  color: #5b21b6;
+  background: rgba(139, 92, 246, 0.2);
+  color: #a78bfa;
   padding: 0.125rem 0.5rem;
   border-radius: 0.75rem;
 }
@@ -423,7 +425,7 @@ onMounted(loadReadings);
 }
 
 .modal {
-  background: white;
+  background: var(--color-bg-secondary);
   border-radius: 0.75rem;
   padding: 1.5rem;
   max-width: 400px;
@@ -433,12 +435,12 @@ onMounted(loadReadings);
 
 .modal h3 {
   margin: 0 0 0.75rem 0;
-  color: #2c3e50;
+  color: var(--color-text-primary);
 }
 
 .modal p {
   margin: 0 0 1.5rem 0;
-  color: #4a5568;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -449,9 +451,9 @@ onMounted(loadReadings);
 }
 
 .cancel-button {
-  background: #f7fafc;
-  color: #4a5568;
-  border: 1px solid #e2e8f0;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
   cursor: pointer;
@@ -459,7 +461,7 @@ onMounted(loadReadings);
 }
 
 .cancel-button:hover {
-  background: #e2e8f0;
+  background: var(--color-bg-hover);
 }
 
 .confirm-delete-button {


### PR DESCRIPTION
Replace hardcoded light-mode hex colors with CSS custom properties throughout
Chat.vue, ReadingHistory.vue, and QuestionForm.vue. Add dark-mode badge overrides
in ChartDataView.vue for status/condition indicators. Apply CSS filter inversion
to the chart wheel SVG in HoraryChart.vue for readability on dark backgrounds.

https://claude.ai/code/session_01GVrNm9aDcBgcQuEdD4Q23o