### PR TITLE
Add follow-up guidance UI and improve horary reading prompts

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -250,6 +250,24 @@ watch(() => props.reading, (newReading) => {
     </div>
 
     <div class="conversation-input">
+      <details class="followup-guide">
+        <summary class="followup-guide-toggle">How do follow-ups work?</summary>
+        <div class="followup-guide-content">
+          <p><strong>Same chart</strong> — this reading can answer:</p>
+          <ul>
+            <li><strong>Timing</strong> — "When might this happen?" uses the same significators already in the chart.</li>
+            <li><strong>Related people or things</strong> — Anyone or anything connected to the original matter. The chart uses derivative houses: your boss (10th), the other party in a deal (7th), a friend's finances (11th's 2nd = 12th), and so on.</li>
+            <li><strong>Clarification</strong> — "What did you mean about Saturn?" or "Can you explain the Moon's role?"</li>
+            <li><strong>Unexplored factors</strong> — Planets, aspects, or house rulers from this chart not yet discussed.</li>
+          </ul>
+          <p><strong>Ask Another Question</strong> — start fresh when:</p>
+          <ul>
+            <li>Your question is about a genuinely different topic or area of life.</li>
+            <li>The situation has materially changed since you asked (a new development occurred).</li>
+          </ul>
+          <p class="followup-guide-note">In horary tradition, one chart belongs to one sincere question and all its branches. Re-casting the same question to get a different answer isn't considered valid practice — the original chart stands.</p>
+        </div>
+      </details>
       <div class="input-container">
         <textarea
           v-model="currentMessage"
@@ -610,5 +628,66 @@ watch(() => props.reading, (newReading) => {
   .message-input {
     font-size: 16px; /* Prevents zoom on iOS */
   }
+}
+
+.followup-guide {
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-bg-tertiary);
+  font-size: 0.875rem;
+}
+
+.followup-guide-toggle {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  user-select: none;
+}
+
+.followup-guide-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.followup-guide-toggle::before {
+  content: '▸';
+  font-size: 0.75rem;
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+
+details[open] .followup-guide-toggle::before {
+  transform: rotate(90deg);
+}
+
+.followup-guide-content {
+  padding: 0 0.75rem 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.followup-guide-content p {
+  margin: 0.5rem 0 0.25rem;
+}
+
+.followup-guide-content ul {
+  margin: 0 0 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.followup-guide-content li {
+  margin: 0.2rem 0;
+}
+
+.followup-guide-note {
+  margin-top: 0.5rem !important;
+  font-style: italic;
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary) !important;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.5rem;
 }
 </style>

--- a/src/prompts/horary-followup.md
+++ b/src/prompts/horary-followup.md
@@ -4,4 +4,26 @@ Traditional framework applies: whole sign houses, traditional seven planets (Sun
 
 Answer follow-up questions conversationally and directly. Do not repeat the full two-part reading structure. Reference specific chart factors from the original reading when relevant. Keep responses concise unless the question calls for detailed explanation.
 
-If the querent asks about something not shown in the chart, say so plainly rather than speculating.
+## Deciding how to respond
+
+### Answer using the same chart when the question is:
+
+**A sub-question or derivative of the original matter** — The same chart covers the entire matter and all its branches. Use derivative houses to explore related people and things: re-read the relevant house as a new Ascendant, then look at its angles. For example, from a job question, the 10th house represents the employer; their 7th (the 4th of the chart) represents the employer's partner; the 6th represents the querent's future colleagues. Walk through the derivative chain and read the significators normally.
+
+**A timing question** — Use the same applying aspects, sign modalities (Cardinal = days/weeks, Mutable = weeks/months, Fixed = months/years), and house types (Angular = quick, Succedent = moderate, Cadent = slow) already visible in the chart.
+
+**A clarification of the initial reading** — Explain any factor from the reading in more depth: a planet's dignity, a specific aspect, what a house placement means for this question.
+
+**An expansion on significators not yet fully discussed** — Other planets, Arabic parts, reception relationships, or house rulers that bear on the matter but weren't covered in the initial reading.
+
+### Guide the querent to "Ask Another Question" when the question is:
+
+**A genuinely different topic** — If the new question has no derivative connection to the original (it involves a different area of life, a different house domain, a different intent), explain briefly why a fresh chart is needed and encourage them to use the "Ask Another Question" button to cast a new chart for that moment of sincere inquiry.
+
+**Based on materially changed circumstances** — If the querent reports a significant new development since the chart was cast (a relationship ended, a job offer came through, a move happened), that new situation warrants its own chart. Acknowledge what changed and suggest a new reading.
+
+**Essentially the same question re-asked** — If the querent appears to be asking the same question again hoping for a different answer, handle this diplomatically. Acknowledge their concern, restate clearly what the chart shows, and explain that the original chart stands as the authoritative reading for that moment. Only suggest a new chart if they describe a genuine change in circumstances.
+
+### Decline to answer when:
+
+The question asks you to speculate beyond what the chart shows, or requests information that is not astrological in nature. In these cases, say so plainly and briefly.


### PR DESCRIPTION
## Summary
This PR enhances the Chat component with educational guidance about follow-up questions in horary readings, and expands the horary follow-up prompt with detailed decision-making logic for the AI assistant.

## Key Changes

**Chat Component (src/components/Chat.vue):**
- Added a collapsible `<details>` element above the message input that explains how follow-ups work in horary astrology
- Includes guidance on when to use the same chart (timing, related people/things, clarification, unexplored factors) vs. when to ask a new question
- Styled with custom CSS including:
  - Animated chevron toggle indicator (rotates 90° when expanded)
  - Consistent color scheme using CSS variables for borders, backgrounds, and text
  - Responsive typography and spacing
  - Custom styling to hide the default browser details marker

**Horary Follow-up Prompt (src/prompts/horary-followup.md):**
- Expanded with a new "Deciding how to respond" section that provides clear decision trees for the AI
- Detailed guidance on when to answer using the same chart (sub-questions, timing, clarification, unexplored significators)
- Instructions for guiding users to ask a new question (different topic, changed circumstances, re-asked questions)
- Guidance on declining to answer when appropriate (speculation beyond chart, non-astrological requests)
- Uses derivative house methodology to explain how related people and topics can be explored within a single chart

## Implementation Details
- The collapsible guide uses semantic HTML `<details>` and `<summary>` elements for accessibility
- CSS custom properties ensure the UI integrates with the existing design system
- The prompt expansion provides nuanced handling of edge cases (e.g., diplomatically addressing users seeking different answers to the same question)

https://claude.ai/code/session_01PKzyayXJPen4jBPeBAMdnz