### PR TITLE
Fix chat response layout: full-width assistant messages and scroll-to…

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -64,7 +64,7 @@ const generateInitialReading = async () => {
       });
       hasInitialReading.value = true;
       emit('conversationUpdate', messages.value);
-      await scrollToBottom();
+      await scrollToLatestMessageTop();
     }
   } catch (error: any) {
     console.error("Error generating initial reading:", error);
@@ -130,7 +130,7 @@ const sendMessage = async () => {
     emit('conversationUpdate', messages.value);
   } finally {
     isLoading.value = false;
-    await scrollToBottom();
+    await scrollToLatestMessageTop();
   }
 };
 
@@ -140,6 +140,19 @@ const scrollToBottom = async () => {
   if (conversationContainer.value) {
     conversationContainer.value.scrollTop =
       conversationContainer.value.scrollHeight;
+  }
+};
+
+// Scroll to the top of the most recently added message
+const scrollToLatestMessageTop = async () => {
+  await nextTick();
+  if (!conversationContainer.value) return;
+  const messageEls = conversationContainer.value.querySelectorAll('.message');
+  if (messageEls.length > 0) {
+    const lastMessage = messageEls[messageEls.length - 1] as HTMLElement;
+    const containerRect = conversationContainer.value.getBoundingClientRect();
+    const msgRect = lastMessage.getBoundingClientRect();
+    conversationContainer.value.scrollTop += (msgRect.top - containerRect.top);
   }
 };
 
@@ -361,6 +374,10 @@ watch(() => props.reading, (newReading) => {
   max-width: 85%;
   display: flex;
   flex-direction: column;
+}
+
+.message.assistant .message-content {
+  max-width: 100%;
 }
 
 .message-text {


### PR DESCRIPTION
## Summary

- **Full-width assistant responses**: LLM responses were capped at 85% (desktop) / 95% (mobile)
  of the chat column width. Added `.message.assistant .message-content { max-width: 100% }` so
  long-form readings fill the available space. User message bubbles are unchanged.
- **Scroll to beginning of response**: `scrollToBottom()` was dropping users at the very end of
  a potentially long reading. Replaced those call sites with `scrollToLatestMessageTop()` which
  uses `getBoundingClientRect()` to scroll the container to the top of the new message.

## Test plan

- [ ] Submit a horary question; confirm the view starts at the first line of the response
- [ ] Send a follow-up; confirm response is shown from the top
- [ ] Verify LLM response text spans the full width of the chat column on desktop and mobile
- [ ] Verify user message bubbles remain right-aligned and width-constrained
- [ ] Confirm scroll-to-bottom still fires after user sends a message (loading indicator visible)
