### PR TITLE
Fix initial reading scroll: clear isLoading before scrollToLatestMess…

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -64,6 +64,7 @@ const generateInitialReading = async () => {
       });
       hasInitialReading.value = true;
       emit('conversationUpdate', messages.value);
+      isLoading.value = false;
       await scrollToLatestMessageTop();
     }
   } catch (error: any) {


### PR DESCRIPTION
…ageTop

The loading indicator (<div class="message assistant">) was still rendered when scrollToLatestMessageTop() ran, because isLoading was only set to false in the finally block — after the scroll call. querySelectorAll('.message') included the loading dot element as the last entry, so the scroll landed at the bottom instead of the top of the new reading.

Fix: set isLoading = false before scrollToLatestMessageTop() in the success path of generateInitialReading(), matching the existing pattern in sendMessage where finally sets isLoading = false before scrolling.

https://claude.ai/code/session_01SuSRssmATtr5KDATRQFtXR