### PR TITLE
Add streaming support for LLM responses

### DIFF
--- a/netlify/functions/llm-proxy.ts
+++ b/netlify/functions/llm-proxy.ts
@@ -1,65 +1,70 @@
-import type { Handler, HandlerEvent } from '@netlify/functions';
-
 const GROQ_API_KEY = process.env.GROQ_FREE_TIER_KEY;
 
-export const handler: Handler = async (event: HandlerEvent) => {
-  // Only allow POST requests
-  if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ error: 'Method not allowed' }),
-    };
+const allowedOrigins = [
+  'http://localhost:5173',
+  'http://localhost:8888',
+  'https://horary-chat.netlify.app',
+];
+
+function getCorsHeaders(origin: string): Record<string, string> {
+  const isAllowed = allowedOrigins.some(o => origin.startsWith(o));
+  return {
+    'Access-Control-Allow-Origin': (isAllowed || !origin) ? (origin || '*') : '',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  const origin = req.headers.get('origin') ?? '';
+  const corsHeaders = getCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
   }
 
-  // Get the origin for CORS
-  const origin = event.headers.origin || '';
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
 
-  // List of allowed origins
-  const allowedOrigins = [
-    'http://localhost:5173',        // Vite dev server
-    'http://localhost:8888',        // Netlify dev
-    'https://horary-chat.netlify.app',   // Production (update with actual domain)
-    // Add more domains as needed
-  ];
-
-  // Check if origin is allowed
-  const isAllowedOrigin = allowedOrigins.some(allowed => origin.startsWith(allowed));
-
+  const isAllowedOrigin = allowedOrigins.some(o => origin.startsWith(o));
   if (!isAllowedOrigin && origin) {
     console.warn(`Blocked request from unauthorized origin: ${origin}`);
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Forbidden - unauthorized origin' }),
-    };
+    return new Response(JSON.stringify({ error: 'Forbidden - unauthorized origin' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
-  // Check if API key is configured
   if (!GROQ_API_KEY) {
     console.error('GROQ_FREE_TIER_KEY environment variable is not set');
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        error: 'Server configuration error - API key not set',
-      }),
-    };
+    return new Response(JSON.stringify({ error: 'Server configuration error - API key not set' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+
+  let requestBody: any;
+  try {
+    requestBody = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+
+  if (!requestBody.model || !requestBody.messages) {
+    return new Response(JSON.stringify({ error: 'Invalid request - missing model or messages' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
   }
 
   try {
-    // Parse request body
-    const requestBody = JSON.parse(event.body || '{}');
-
-    // Validate request has required fields
-    if (!requestBody.model || !requestBody.messages) {
-      return {
-        statusCode: 400,
-        body: JSON.stringify({
-          error: 'Invalid request - missing model or messages',
-        }),
-      };
-    }
-
-    // Forward request to Groq
-    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    const groqResponse = await fetch('https://api.groq.com/openai/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -68,48 +73,42 @@ export const handler: Handler = async (event: HandlerEvent) => {
       body: JSON.stringify(requestBody),
     });
 
-    const data = await response.json();
-
-    // Check if Groq returned an error
-    if (!response.ok) {
-      console.error('Groq API error:', data);
-      return {
-        statusCode: response.status,
-        headers: {
-          'Access-Control-Allow-Origin': origin || '*',
-          'Access-Control-Allow-Headers': 'Content-Type',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          error: data.error?.message || 'Groq API error',
-          details: data,
-        }),
-      };
+    if (!groqResponse.ok) {
+      const errData = await groqResponse.json();
+      console.error('Groq API error:', errData);
+      return new Response(JSON.stringify({
+        error: errData.error?.message || 'Groq API error',
+        details: errData,
+      }), {
+        status: groqResponse.status,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      });
     }
 
-    // Return successful response
-    return {
-      statusCode: 200,
-      headers: {
-        'Access-Control-Allow-Origin': origin || '*',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    };
+    if (requestBody.stream) {
+      return new Response(groqResponse.body, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          ...corsHeaders,
+        },
+      });
+    }
+
+    const data = await groqResponse.json();
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
   } catch (error: any) {
     console.error('Proxy error:', error);
-    return {
-      statusCode: 500,
-      headers: {
-        'Access-Control-Allow-Origin': origin || '*',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        error: 'Internal server error',
-        message: error.message,
-      }),
-    };
+    return new Response(JSON.stringify({
+      error: 'Internal server error',
+      message: error.message,
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
   }
-};
+}

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -13,6 +13,7 @@ interface ConversationMessage {
   content: string;
   timestamp: Date;
   isError?: boolean;
+  isStreaming?: boolean;
 }
 
 const props = defineProps<{
@@ -54,29 +55,47 @@ const generateInitialReading = async () => {
   if (hasInitialReading.value) return;
 
   isLoading.value = true;
+
+  // Add a streaming placeholder message right away
+  const streamingIndex = messages.value.length;
+  messages.value.push({
+    role: "assistant",
+    content: "",
+    timestamp: new Date(),
+    isStreaming: true,
+  });
+
   try {
-    const reading = await generateHoraryReading(props.reading);
-    if (reading) {
-      messages.value.push({
-        role: "assistant",
-        content: reading,
-        timestamp: new Date(),
-      });
+    let firstChunk = true;
+    const reading = await generateHoraryReading(props.reading, (chunk: string) => {
+      if (firstChunk) {
+        firstChunk = false;
+        isLoading.value = false;
+        scrollToLatestMessageTop();
+      }
+      messages.value[streamingIndex].content += chunk;
+      scrollToBottomIfNear();
+    });
+
+    if (!reading) {
+      messages.value.splice(streamingIndex, 1);
+    } else {
       hasInitialReading.value = true;
-      emit('conversationUpdate', messages.value);
-      isLoading.value = false;
-      await scrollToLatestMessageTop();
     }
+    emit('conversationUpdate', messages.value);
   } catch (error: any) {
     console.error("Error generating initial reading:", error);
-    messages.value.push({
+    messages.value[streamingIndex] = {
       role: "assistant",
       content: formatErrorMessage(error),
       timestamp: new Date(),
       isError: true,
-    });
+    };
     emit('conversationUpdate', messages.value);
   } finally {
+    if (messages.value[streamingIndex]) {
+      messages.value[streamingIndex].isStreaming = false;
+    }
     isLoading.value = false;
   }
 };
@@ -99,39 +118,55 @@ const sendMessage = async () => {
   await scrollToBottom();
   isLoading.value = true;
 
-  try {
-    // Get conversation history (excluding the chart data message)
-    const history = messages.value.slice(1).map((msg) => ({
-      role: msg.role,
-      content: msg.content,
-    }));
+  // Snapshot history before adding the streaming placeholder
+  const history = messages.value.slice(1).map((msg) => ({
+    role: msg.role as "user" | "assistant",
+    content: msg.content,
+  }));
 
+  // Add streaming placeholder
+  const streamingIndex = messages.value.length;
+  messages.value.push({
+    role: "assistant",
+    content: "",
+    timestamp: new Date(),
+    isStreaming: true,
+  });
+
+  try {
+    let firstChunk = true;
     const response = await continueHoraryConversation(
       props.reading,
       history,
-      userMessage
+      userMessage,
+      (chunk: string) => {
+        if (firstChunk) {
+          firstChunk = false;
+          isLoading.value = false;
+        }
+        messages.value[streamingIndex].content += chunk;
+        scrollToBottomIfNear();
+      }
     );
 
-    if (response) {
-      messages.value.push({
-        role: "assistant",
-        content: response,
-        timestamp: new Date(),
-      });
-      emit('conversationUpdate', messages.value);
+    if (!response) {
+      messages.value.splice(streamingIndex, 1);
     }
+    emit('conversationUpdate', messages.value);
   } catch (error: any) {
     console.error("Error in conversation:", error);
-    messages.value.push({
+    messages.value[streamingIndex] = {
       role: "assistant",
       content: formatErrorMessage(error),
       timestamp: new Date(),
       isError: true,
-    });
+    };
     emit('conversationUpdate', messages.value);
   } finally {
+    if (messages.value[streamingIndex]) {
+      messages.value[streamingIndex].isStreaming = false;
+    }
     isLoading.value = false;
-    await scrollToLatestMessageTop();
   }
 };
 
@@ -142,6 +177,14 @@ const scrollToBottom = async () => {
     conversationContainer.value.scrollTop =
       conversationContainer.value.scrollHeight;
   }
+};
+
+// Scroll to bottom only if user is already near the bottom (during streaming)
+const scrollToBottomIfNear = () => {
+  const el = conversationContainer.value;
+  if (!el) return;
+  const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+  if (isNearBottom) el.scrollTop = el.scrollHeight;
 };
 
 // Scroll to the top of the most recently added message
@@ -201,6 +244,20 @@ function formatMessageContent(content: string): string {
   });
 }
 
+// Render message content: raw escaped text with cursor during streaming,
+// full markdown after streaming completes.
+function renderMessage(message: ConversationMessage): string {
+  if (message.isStreaming) {
+    const escaped = message.content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>');
+    return escaped + '<span class="streaming-cursor"></span>';
+  }
+  return formatMessageContent(message.content);
+}
+
 // Auto-generate initial reading when reading prop is available
 watch(() => props.reading, (newReading) => {
   if (newReading && !hasInitialReading.value) {
@@ -243,12 +300,12 @@ watch(() => props.reading, (newReading) => {
           <div class="message-content">
             <div
               class="message-text"
-              v-html="formatMessageContent(message.content)"></div>
-            <div class="message-time">{{ formatTime(message.timestamp) }}</div>
+              v-html="renderMessage(message)"></div>
+            <div v-if="!message.isStreaming" class="message-time">{{ formatTime(message.timestamp) }}</div>
           </div>
         </div>
 
-        <div v-if="isLoading" class="message assistant">
+        <div v-if="isLoading && !messages.some(m => m.isStreaming)" class="message assistant">
           <div class="message-content">
             <div class="loading-indicator">
               <div class="loading-dots">
@@ -557,6 +614,21 @@ watch(() => props.reading, (newReading) => {
   40% {
     transform: scale(1);
   }
+}
+
+.streaming-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: currentColor;
+  vertical-align: text-bottom;
+  margin-left: 1px;
+  animation: blink-cursor 0.8s step-end infinite;
+}
+
+@keyframes blink-cursor {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
 }
 
 .loading-text {

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -430,7 +430,8 @@ function formatChartForLLM(reading: HoraryReading): string {
 
 // Updated LLM generation function
 export const generateHoraryReading = async (
-  reading: HoraryReading
+  reading: HoraryReading,
+  onChunk?: (chunk: string) => void
 ): Promise<string | null> => {
   try {
     const settings = loadSettings();
@@ -472,12 +473,39 @@ Then provide the technical analysis using proper astrological terminology. ALWAY
 
 Proceed directly with your traditional horary judgment.`;
 
+    const messages = [
+      { role: "system" as const, content: horaryBasePrompt },
+      { role: "user" as const, content: prompt },
+    ];
+
+    if (onChunk) {
+      const stream = openai.chat.completions.stream({
+        model,
+        messages,
+        temperature: 0.7,
+        max_tokens: 2000,
+      });
+
+      let fullContent = '';
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta?.content ?? '';
+        if (delta) {
+          fullContent += delta;
+          onChunk(delta);
+        }
+      }
+
+      if (settings.provider === 'openrouter-free') {
+        const final = await stream.finalChatCompletion();
+        recordUsage(final.usage?.total_tokens || 0);
+      }
+
+      return fullContent;
+    }
+
     const response = await openai.chat.completions.create({
       model,
-      messages: [
-        { role: "system", content: horaryBasePrompt },
-        { role: "user", content: prompt },
-      ],
+      messages,
       temperature: 0.7,
       max_tokens: 2000,
     });
@@ -499,7 +527,8 @@ Proceed directly with your traditional horary judgment.`;
 export const continueHoraryConversation = async (
   reading: HoraryReading,
   conversationHistory: Array<{ role: "user" | "assistant"; content: string }>,
-  newMessage: string
+  newMessage: string,
+  onChunk?: (chunk: string) => void
 ): Promise<string | null> => {
   try {
     const settings = loadSettings();
@@ -526,6 +555,31 @@ export const continueHoraryConversation = async (
       ...conversationHistory,
       { role: "user" as const, content: newMessage },
     ];
+
+    if (onChunk) {
+      const stream = openai.chat.completions.stream({
+        model,
+        messages,
+        temperature: 0.7,
+        max_tokens: 1500,
+      });
+
+      let fullContent = '';
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta?.content ?? '';
+        if (delta) {
+          fullContent += delta;
+          onChunk(delta);
+        }
+      }
+
+      if (settings.provider === 'openrouter-free') {
+        const final = await stream.finalChatCompletion();
+        recordUsage(final.usage?.total_tokens || 0);
+      }
+
+      return fullContent;
+    }
 
     const response = await openai.chat.completions.create({
       model,


### PR DESCRIPTION
## Summary

- Migrated LLM proxy function from Netlify handler format to standard Web API (Request/Response)
- Added streaming support to both `generateHoraryReading` and `continueHoraryConversation` functions with optional `onChunk` callbacks
- Implemented real-time message streaming in Chat component with visual streaming cursor
- Enhanced CORS handling with origin validation and proper header management
- Improved error handling for streaming responses and invalid JSON payloads
- Added `isStreaming` flag to messages to distinguish between streaming and completed responses

## Test plan

- [ ] `npm run build` passes
- [ ] Manual verification:
  - Generate initial horary reading and verify streaming text appears in real-time
  - Send follow-up messages and verify streaming responses display with cursor animation
  - Test CORS by verifying requests from allowed origins succeed and blocked origins are rejected
  - Verify error messages display correctly when API calls fail
  - Test with both streaming and non-streaming LLM providers

## Notes

The proxy function now uses the Web API standard (Request/Response) instead of Netlify's handler format, making it compatible with edge functions and other serverless platforms. Streaming is opt-in via the `onChunk` callback parameter, maintaining backward compatibility with non-streaming code paths.

https://claude.ai/code/session_01Mh629YJWhWRAMwVcaobdpL