### PR TITLE
redesign color scheme with warm occult aesthetic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -118,24 +118,25 @@ const storageStats = getStorageStats();
 
 /* CSS Custom Properties for Theming */
 :root {
-  /* Light mode colors */
-  --color-bg-primary: #f7fafc;
-  --color-bg-secondary: #ffffff;
-  --color-bg-tertiary: #f7fafc;
-  --color-bg-hover: #e2e8f0;
-  --color-bg-active: #4a90e2;
+  /* Light mode — warm parchment with gold/amber highlights */
+  --color-bg-primary: #fdf8f0;
+  --color-bg-secondary: #fffcf5;
+  --color-bg-tertiary: #fdf1dc;
+  --color-bg-hover: #f5e6c0;
+  --color-bg-active: #d97706;
 
-  --color-text-primary: #2c3e50;
-  --color-text-secondary: #4a5568;
-  --color-text-tertiary: #718096;
-  --color-text-inverse: #ffffff;
+  --color-text-primary: #2d1f0e;
+  --color-text-secondary: #6b4c2a;
+  --color-text-tertiary: #9a7148;
+  --color-text-inverse: #fffcf5;
 
-  --color-border: #e2e8f0;
-  --color-border-focus: #cbd5e0;
+  --color-border: #e8d5a8;
+  --color-border-focus: #c9a84c;
 
-  --color-accent: #4a90e2;
-  --color-success: #10b981;
-  --color-warning: #fbbf24;
+  --color-accent: #d97706;
+  --color-accent-hover: #b45309;
+  --color-success: #65a30d;
+  --color-warning: #f59e0b;
   --color-error: #dc2626;
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -143,30 +144,31 @@ const storageStats = getStorageStats();
   --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
-/* Dark mode colors */
+/* Dark mode — brownish black with cream text, gold and forest green */
 :root.dark {
-  --color-bg-primary: #111827;
-  --color-bg-secondary: #1e293b;
-  --color-bg-tertiary: #374151;
-  --color-bg-hover: #4a5568;
-  --color-bg-active: #4a90e2;
+  --color-bg-primary: #1a0e05;
+  --color-bg-secondary: #261507;
+  --color-bg-tertiary: #3d2010;
+  --color-bg-hover: #522b14;
+  --color-bg-active: #b45309;
 
-  --color-text-primary: #f7fafc;
-  --color-text-secondary: #e2e8f0;
-  --color-text-tertiary: #cbd5e0;
-  --color-text-inverse: #1a202c;
+  --color-text-primary: #fdf4dc;
+  --color-text-secondary: #e8d5b0;
+  --color-text-tertiary: #c4a882;
+  --color-text-inverse: #1a0e05;
 
-  --color-border: #4a5568;
-  --color-border-focus: #718096;
+  --color-border: #6b3d0f;
+  --color-border-focus: #a0591c;
 
-  --color-accent: #63b3ed;
-  --color-success: #34d399;
-  --color-warning: #fbbf24;
+  --color-accent: #f59e0b;
+  --color-accent-hover: #d97706;
+  --color-success: #2d6a4f;
+  --color-warning: #d97706;
   --color-error: #f87171;
 
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.3);
-  --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.4);
 }
 
 body {
@@ -223,9 +225,9 @@ body {
 }
 
 .info-tag {
-  background: rgba(74, 144, 226, 0.08);
+  background: rgba(217, 119, 6, 0.08);
   color: var(--color-text-tertiary);
-  border: 1px solid rgba(74, 144, 226, 0.2);
+  border: 1px solid rgba(217, 119, 6, 0.2);
   border-radius: 9999px;
   font-size: 0.6875rem;
   font-weight: 500;
@@ -238,9 +240,9 @@ body {
 }
 
 .info-tag:hover {
-  background: rgba(74, 144, 226, 0.15);
+  background: rgba(217, 119, 6, 0.15);
   color: var(--color-accent);
-  border-color: rgba(74, 144, 226, 0.35);
+  border-color: rgba(217, 119, 6, 0.35);
 }
 
 .header-actions {

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -488,8 +488,8 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message.user .message-text {
-  background: #4a90e2;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
   border-bottom-right-radius: 0.25rem;
 }
 
@@ -536,7 +536,7 @@ watch(() => props.reading, (newReading) => {
 .loading-dots span {
   width: 6px;
   height: 6px;
-  background: #4a90e2;
+  background: var(--color-accent);
   border-radius: 50%;
   animation: loading-bounce 1.4s ease-in-out infinite both;
 }
@@ -602,8 +602,8 @@ watch(() => props.reading, (newReading) => {
 }
 
 .send-button {
-  background: #4a90e2;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
   border: none;
   border-radius: 0.5rem;
   padding: 0.75rem;
@@ -617,7 +617,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .send-button:hover:not(:disabled) {
-  background: #357abd;
+  background: var(--color-accent-hover);
 }
 
 .send-button:disabled {

--- a/src/components/QuestionForm.vue
+++ b/src/components/QuestionForm.vue
@@ -267,25 +267,25 @@ textarea:focus {
 }
 
 textarea.error {
-  border-color: #e53e3e;
+  border-color: var(--color-error);
 }
 
 .error-message {
-  color: #e53e3e;
+  color: var(--color-error);
   font-size: 0.875rem;
   margin-top: 0.25rem;
   display: block;
 }
 
 .location-error {
-  color: #e53e3e;
+  color: var(--color-error);
   font-size: 0.875rem;
   margin: 0.25rem 0;
 }
 
 .submit-button {
-  background-color: #4a90e2;
-  color: white;
+  background-color: var(--color-accent);
+  color: var(--color-text-inverse);
   padding: 0.75rem 1.5rem;
   border: none;
   border-radius: 0.5rem;
@@ -298,7 +298,7 @@ textarea.error {
 }
 
 .submit-button:hover:not(:disabled) {
-  background-color: #357abd;
+  background-color: var(--color-accent-hover);
 }
 
 .submit-button:disabled {
@@ -357,7 +357,7 @@ textarea.error {
 
 .datetime-input:focus {
   outline: none;
-  border-color: #4a90e2;
+  border-color: var(--color-accent);
 }
 
 .field-hint {
@@ -399,8 +399,8 @@ textarea.error {
 .refresh-location,
 .get-location-btn {
   padding: 0.5rem 1rem;
-  background: #4a90e2;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
   border: none;
   border-radius: 0.375rem;
   font-size: 0.875rem;
@@ -410,7 +410,7 @@ textarea.error {
 
 .refresh-location:hover,
 .get-location-btn:hover {
-  background: #357abd;
+  background: var(--color-accent-hover);
 }
 
 /* Mobile optimizations */

--- a/src/components/ReadingHistory.vue
+++ b/src/components/ReadingHistory.vue
@@ -352,8 +352,8 @@ onMounted(loadReadings);
 }
 
 .reading-card:hover {
-  border-color: #4a90e2;
-  box-shadow: 0 2px 8px rgba(74, 144, 226, 0.1);
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 8px rgba(217, 119, 6, 0.12);
 }
 
 .reading-header {
@@ -382,7 +382,7 @@ onMounted(loadReadings);
 }
 
 .delete-button:hover {
-  color: #ef4444;
+  color: var(--color-error);
 }
 
 .reading-question {
@@ -400,8 +400,8 @@ onMounted(loadReadings);
 }
 
 .conversation-count {
-  background: rgba(139, 92, 246, 0.2);
-  color: #a78bfa;
+  background: rgba(217, 119, 6, 0.15);
+  color: var(--color-accent);
   padding: 0.125rem 0.5rem;
   border-radius: 0.75rem;
 }
@@ -465,7 +465,7 @@ onMounted(loadReadings);
 }
 
 .confirm-delete-button {
-  background: #ef4444;
+  background: var(--color-error);
   color: white;
   border: none;
   padding: 0.5rem 1rem;
@@ -475,7 +475,8 @@ onMounted(loadReadings);
 }
 
 .confirm-delete-button:hover {
-  background: #dc2626;
+  background: var(--color-error);
+  filter: brightness(0.85);
 }
 
 /* Mobile optimizations */


### PR DESCRIPTION
Light mode: warm parchment (#fdf8f0) backgrounds with gold/amber/orange accent (#d97706) and warm brown text, replacing cold blue-gray palette.

Dark mode: deep brownish-black (#1a0e05) with cream text (#fdf4dc), bright gold accent (#f59e0b), and forest green success (#2d6a4f).

Also converts all hardcoded #4a90e2 blues in Chat, QuestionForm, and ReadingHistory to CSS variables so they inherit the new theme correctly.

https://claude.ai/code/session_01WgDjtaH6Emdv2ZPP3NqB4X

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
