### PR TITLE
Fix LLM timing responses to reflect question-specific time scales

### DIFF
--- a/src/prompts/horary-base.md
+++ b/src/prompts/horary-base.md
@@ -133,11 +133,23 @@ Quick reference (full detail is in the chart data):
 **Judgment:** Well-placed PoF (strong dispositor) = querent has resources. Poorly placed = lacks capacity despite desire.
 
 ### 10. Timing
-**Sign Type:** Cardinal: days-weeks (fast) | Fixed: months-years (slow) | Mutable: weeks-months (medium)
-**House Type:** Angular: quick | Succedent: moderate | Cadent: slow
-**Orb:** Smaller orb = sooner. Larger = later.
 
-Use provided timing estimates as context, NOT exact dates.
+**Step 1 — Identify the question's natural time scale:**
+Different questions have different inherent scopes. Determine which category applies before touching chart factors:
+- **Immediate** (lost objects, today's events, imminent decisions): base unit = hours to 1-2 days
+- **Near-term** (job offers, short journeys, pending replies, test results): base unit = days to a few weeks
+- **Medium-term** (relationships developing, health recovery, moves, projects): base unit = weeks to months
+- **Long-term** (marriage, major career change, protracted legal matters, fertility): base unit = months to years
+
+**Step 2 — Apply sign and house modifiers within that scale:**
+- **Sign:** Cardinal → faster end of base range | Mutable → middle | Fixed → slower end (or beyond)
+- **House:** Angular → quicker | Succedent → moderate | Cadent → slower
+- **Orb:** Smaller orb = sooner. Larger = later.
+
+**Step 3 — Cross-check with pre-computed chart data:**
+The chart data includes ⏱ Timing sections on applying aspects and aspect orbs expressed in days. Use these as your primary reference; adjust the narrative unit (hours/days/weeks/months) to match the question's natural scope.
+
+**CRITICAL:** The same 5° applying orb means different things depending on the question. It could mean "about 5 days" for a lost-object question and "about 5 months" for a marriage question. Always anchor the time unit to the question's natural scope first, then let sign/house modifiers push faster or slower within that range.
 
 <!-- [ADJUSTABLE: May be simplified to fewer steps for smaller models] -->
 ### 11. Judgment Sequence
@@ -167,7 +179,7 @@ Use provided timing estimates as context, NOT exact dates.
 - Give clear, direct answer (2-3 paragraphs)
 - State success/failure/uncertain with reasoning anyone can understand
 - Give a clear verdict — yes, no, or qualified with specific astrological conditions. Do not hedge with generic practical advice. Every statement must trace back to a named chart factor.
-- Include timing if applicable (e.g., "within 2-3 weeks" not "when Moon applies to Saturn")
+- Include timing calibrated to the question's nature — could be "within a few hours" for urgent matters, "within days" for near-term questions, "within weeks to months" for medium-term situations, or "within months to years" for long-term matters. Always cite the chart factor that supports the timing (e.g., "the 3° applying trine in a cardinal sign suggests resolution within about 3 days").
 - Should be completely standalone - someone with zero astrology knowledge should understand this section
 
 ### 2. Detailed Astrological Analysis (SECOND) - Technical Details

--- a/src/prompts/horary-followup.md
+++ b/src/prompts/horary-followup.md
@@ -10,7 +10,7 @@ Answer follow-up questions conversationally and directly. Do not repeat the full
 
 **A sub-question or derivative of the original matter** — The same chart covers the entire matter and all its branches. Use derivative houses to explore related people and things: re-read the relevant house as a new Ascendant, then look at its angles. For example, from a job question, the 10th house represents the employer; their 7th (the 4th of the chart) represents the employer's partner; the 6th represents the querent's future colleagues. Walk through the derivative chain and read the significators normally.
 
-**A timing question** — Use the same applying aspects, sign modalities (Cardinal = days/weeks, Mutable = weeks/months, Fixed = months/years), and house types (Angular = quick, Succedent = moderate, Cadent = slow) already visible in the chart.
+**A timing question** — Use the same applying aspects, sign modalities (Cardinal = faster, Mutable = medium, Fixed = slower), and house types (Angular = quick, Succedent = moderate, Cadent = slow) already visible in the chart. Calibrate the time unit (hours / days / weeks / months / years) to the question's natural scope: urgent practical matters resolve in hours or days; near-term outcomes in days to weeks; medium-term situations in weeks to months; long-term life events in months to years.
 
 **A clarification of the initial reading** — Explain any factor from the reading in more depth: a planet's dignity, a specific aspect, what a house placement means for this question.
 


### PR DESCRIPTION
The LLM was defaulting to "1-6 weeks" for every question regardless of context. The root causes were:

1. Section 10 (Timing) in the system prompt only listed generic sign/ house modifiers without anchoring them to the question's inherent time scale.
2. The example in the response structure ("within 2-3 weeks") anchored the model toward weeks for all question types.

Fix: restructure Section 10 as a three-step process:
  Step 1 — Classify question scope first (immediate/near-term/medium-
            term/long-term) to set the correct time unit before
            applying any chart modifiers.
  Step 2 — Apply sign/house/orb modifiers within that calibrated range.
  Step 3 — Cross-check against the pre-computed ⏱ Timing sections and
            orb-in-days values already present in the chart data.

Also update the response-structure guidance to show the full range of possible time expressions (hours → days → weeks/months → months/years) and require citing the specific chart factor that justifies the timing.

Apply the same calibration language to horary-followup.md for follow-up timing questions.

https://claude.ai/code/session_012j3opzm5vejQL3CzSkdoNe

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
