### PR TITLE
Add Qwen3-32B and Qwen-2.5-32B to Groq free tier model options

### DIFF
--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -71,8 +71,10 @@ export const PROVIDER_CONFIGS: Record<LLMProvider, ProviderConfig> = {
     description: 'Try the app with Groq\'s free tier. Fast responses with generous limits.',
     requiresApiKey: false,
     supportsLocal: false,
-    defaultModel: 'llama-3.3-70b-versatile',
+    defaultModel: 'qwen/qwen3-32b',
     suggestedModels: [
+      'qwen/qwen3-32b',
+      'qwen-2.5-32b',
       'llama-3.3-70b-versatile',
       'llama-3.1-8b-instant',
     ],


### PR DESCRIPTION
Groq now offers Qwen3-32B (qwen/qwen3-32b) on the free tier with 128k context and built-in thinking mode — well-suited for horary interpretation which benefits from considered, multi-step reasoning. Also adds Qwen-2.5-32B as an alternative.

Makes qwen/qwen3-32b the new default for the free tier provider, replacing llama-3.3-70b-versatile. Llama models are kept in suggestedModels so existing users with saved preferences are unaffected.

No proxy or storage changes needed — llm-proxy.ts already forwards any model ID to Groq, and PROVIDER_CONFIGS is the single source of truth the UI reads from.

https://claude.ai/code/session_01Bep7M7rZpdghQg7f1zvWA7

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
