### PR TITLE
Add SessionStart hook to install gh and npm deps in web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install gh CLI if not already present
+if ! command -v gh &>/dev/null; then
+  apt-get install -y gh
+fi
+
+# Install npm dependencies (skip Puppeteer's Chromium download — not needed for tests/build)
+cd "$CLAUDE_PROJECT_DIR"
+PUPPETEER_SKIP_DOWNLOAD=1 npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,15 @@
             "command": "entire hooks claude-code session-start"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
Installs the GitHub CLI (gh) and project npm dependencies automatically at the start of each remote Claude Code session. This makes `gh` available for PR creation without manual intervention each time.

- Skips Puppeteer's Chromium download (not needed for tests/build)
- No-ops in local (non-remote) environments
- Registered alongside the existing entire-hooks session-start entry

https://claude.ai/code/session_01Bep7M7rZpdghQg7f1zvWA7

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
