### PR TITLE
fix: catch PR approval error in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -61,13 +61,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: Number('${{ steps.get-pr.outputs.pr_number }}'),
-              event: 'APPROVE',
-              body: 'Auto-approved: CI passed on a `claude/*` branch.',
-            });
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number('${{ steps.get-pr.outputs.pr_number }}'),
+                event: 'APPROVE',
+                body: 'Auto-approved: CI passed on a `claude/*` branch.',
+              });
+            } catch (err) {
+              core.warning(`Could not approve PR (to enable, go to Settings → Actions → General → "Allow GitHub Actions to approve pull requests"): ${err.message}`);
+            }
 
       - name: Enable auto-merge (squash)
         if: >


### PR DESCRIPTION
GitHub Actions cannot approve PRs unless 'Allow GitHub Actions to approve pull requests' is enabled in repo settings. Wrap the createReview call in try/catch so the job continues to the merge step instead of failing entirely.

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
