### PR TITLE
Add shareable reading links via URL encoding

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import UserChat from "./components/UserChat.vue";
 import ReadingHistory from "./components/ReadingHistory.vue";
 import LLMSettings from "./components/LLMSettings.vue";
 import HoraryInfoModal from "./components/HoraryInfoModal.vue";
-import { useReadingStorage, type StoredReading } from './utils/storage';
+import { useReadingStorage, decodeReadingFromUrl, type StoredReading } from './utils/storage';
 import { useDarkMode } from './composables/useDarkMode';
 
 type AppView = 'chat' | 'history';
@@ -34,6 +34,17 @@ const handleSelectReading = (reading: StoredReading) => {
 };
 
 const storageStats = getStorageStats();
+
+onMounted(() => {
+  const sharedReading = decodeReadingFromUrl();
+  if (sharedReading) {
+    selectedHistoryReading.value = sharedReading;
+    // Remove the ?share= param from the URL without a page reload
+    const url = new URL(window.location.href);
+    url.searchParams.delete("share");
+    window.history.replaceState({}, "", url.toString());
+  }
+});
 </script>
 
 <template>

--- a/src/components/ReadingHistory.vue
+++ b/src/components/ReadingHistory.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
-import { useReadingStorage, type StoredReading } from "../utils/storage";
+import { useReadingStorage, encodeReadingToUrl, type StoredReading } from "../utils/storage";
 
 const emit = defineEmits<{
   (e: "select-reading", reading: StoredReading): void;
@@ -15,6 +15,7 @@ const searchQuery = ref("");
 const isLoading = ref(false);
 const showConfirmDelete = ref(false);
 const readingToDelete = ref<StoredReading | null>(null);
+const copiedReadingId = ref<string | null>(null);
 
 // Computed filtered readings
 const filteredReadings = computed(() => {
@@ -85,6 +86,30 @@ const handleDelete = async () => {
     readingToDelete.value = null;
   } catch (error) {
     console.error("Error deleting reading:", error);
+  }
+};
+
+// Copy share link for a reading
+const copyShareLink = async (reading: StoredReading) => {
+  const url = encodeReadingToUrl(reading);
+  try {
+    await navigator.clipboard.writeText(url);
+    copiedReadingId.value = reading.id;
+    setTimeout(() => {
+      copiedReadingId.value = null;
+    }, 2000);
+  } catch {
+    // Fallback: select from a temporary input
+    const input = document.createElement("input");
+    input.value = url;
+    document.body.appendChild(input);
+    input.select();
+    document.execCommand("copy");
+    document.body.removeChild(input);
+    copiedReadingId.value = reading.id;
+    setTimeout(() => {
+      copiedReadingId.value = null;
+    }, 2000);
   }
 };
 
@@ -166,18 +191,41 @@ onMounted(loadReadings);
                     })
                   }}
                 </span>
-                <button
-                  @click.stop="confirmDelete(reading)"
-                  class="delete-button"
-                  title="Delete reading">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                    <path
-                      d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round" />
-                  </svg>
-                </button>
+                <div class="reading-actions">
+                  <button
+                    @click.stop="copyShareLink(reading)"
+                    class="share-button"
+                    :title="copiedReadingId === reading.id ? 'Link copied!' : 'Copy share link'">
+                    <svg v-if="copiedReadingId !== reading.id" width="16" height="16" viewBox="0 0 24 24" fill="none">
+                      <path
+                        d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round" />
+                    </svg>
+                    <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none">
+                      <path
+                        d="M5 13l4 4L19 7"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round" />
+                    </svg>
+                  </button>
+                  <button
+                    @click.stop="confirmDelete(reading)"
+                    class="delete-button"
+                    title="Delete reading">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                      <path
+                        d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round" />
+                    </svg>
+                  </button>
+                </div>
               </div>
 
               <div class="reading-question">
@@ -367,6 +415,30 @@ onMounted(loadReadings);
   font-size: 0.875rem;
   color: var(--color-text-tertiary);
   font-weight: 500;
+}
+
+.reading-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.share-button {
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  border-radius: 0.25rem;
+  transition: color 0.2s;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.share-button:hover {
+  color: var(--color-accent);
 }
 
 .delete-button {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -181,6 +181,30 @@ class ReadingStorage {
 // Create and export a singleton instance
 export const readingStorage = new ReadingStorage();
 
+// Encode a reading into a shareable URL
+export function encodeReadingToUrl(reading: StoredReading): string {
+  const json = JSON.stringify(reading);
+  const encoded = btoa(encodeURIComponent(json));
+  const url = new URL(window.location.href);
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set("share", encoded);
+  return url.toString();
+}
+
+// Decode a shared reading from the current URL's ?share= param
+export function decodeReadingFromUrl(): StoredReading | null {
+  const params = new URLSearchParams(window.location.search);
+  const encoded = params.get("share");
+  if (!encoded) return null;
+  try {
+    const json = decodeURIComponent(atob(encoded));
+    return JSON.parse(json) as StoredReading;
+  } catch {
+    return null;
+  }
+}
+
 // Hook for Vue components
 export function useReadingStorage() {
   return {


### PR DESCRIPTION
Implements the "Share Links" stretch goal from the roadmap. Readings can now be shared without authentication by encoding the reading data into a base64 URL param (?share=...). Recipients see the shared reading on load; no backend or user accounts required.

- storage.ts: add encodeReadingToUrl() and decodeReadingFromUrl() helpers
- ReadingHistory.vue: add Share button per reading (copies link to clipboard)
- App.vue: on mount, decode ?share= param and display the shared reading

https://claude.ai/code/session_012X2cgonQ9zzRMyXAXPVvh1

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
