### PR TITLE
Fix share links: compress URL payload and save shared readings to his…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@ import UserChat from "./components/UserChat.vue";
 import ReadingHistory from "./components/ReadingHistory.vue";
 import LLMSettings from "./components/LLMSettings.vue";
 import HoraryInfoModal from "./components/HoraryInfoModal.vue";
-import { useReadingStorage, decodeReadingFromUrl, type StoredReading } from './utils/storage';
+import { readingStorage, decodeReadingFromUrl, type StoredReading } from './utils/storage';
 import { useDarkMode } from './composables/useDarkMode';
 
 type AppView = 'chat' | 'history';
@@ -12,7 +12,6 @@ type AppView = 'chat' | 'history';
 const currentView = ref<AppView>('chat');
 const selectedHistoryReading = ref<StoredReading | null>(null);
 const chatResetKey = ref(0); // Used to force UserChat component to reset
-const { getStorageStats } = useReadingStorage();
 const { isDark, toggleDarkMode } = useDarkMode();
 const showSettings = ref(false);
 const showHoraryInfo = ref(false);
@@ -33,11 +32,12 @@ const handleSelectReading = (reading: StoredReading) => {
   currentView.value = 'chat';
 };
 
-const storageStats = getStorageStats();
+const storageStats = readingStorage.getStorageStats();
 
-onMounted(() => {
-  const sharedReading = decodeReadingFromUrl();
+onMounted(async () => {
+  const sharedReading = await decodeReadingFromUrl();
   if (sharedReading) {
+    readingStorage.importReading(sharedReading);
     selectedHistoryReading.value = sharedReading;
     // Remove the ?share= param from the URL without a page reload
     const url = new URL(window.location.href);

--- a/src/components/ReadingHistory.vue
+++ b/src/components/ReadingHistory.vue
@@ -91,7 +91,7 @@ const handleDelete = async () => {
 
 // Copy share link for a reading
 const copyShareLink = async (reading: StoredReading) => {
-  const url = encodeReadingToUrl(reading);
+  const url = await encodeReadingToUrl(reading);
   try {
     await navigator.clipboard.writeText(url);
     copiedReadingId.value = reading.id;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -140,6 +140,19 @@ class ReadingStorage {
     }
   }
 
+  // Import a complete reading (e.g. from a share link), deduplicating by ID
+  importReading(reading: StoredReading): void {
+    const readings = this.getAllReadings();
+    if (!readings.some(r => r.id === reading.id)) {
+      readings.unshift(reading);
+      try {
+        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(readings));
+      } catch (error) {
+        console.error("Error importing reading:", error);
+      }
+    }
+  }
+
   // Generate a unique ID
   private generateId(): string {
     return Date.now().toString(36) + Math.random().toString(36).substr(2);
@@ -181,25 +194,54 @@ class ReadingStorage {
 // Create and export a singleton instance
 export const readingStorage = new ReadingStorage();
 
-// Encode a reading into a shareable URL
-export function encodeReadingToUrl(reading: StoredReading): string {
-  const json = JSON.stringify(reading);
-  const encoded = btoa(encodeURIComponent(json));
+// Encode a reading into a shareable URL (gzip + URL-safe base64)
+export async function encodeReadingToUrl(reading: StoredReading): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(reading));
+  const stream = new ReadableStream({
+    start(c) { c.enqueue(bytes); c.close(); },
+  });
+  const compressed = stream.pipeThrough(new CompressionStream("gzip"));
+  const chunks: Uint8Array[] = [];
+  const reader = compressed.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) { out.set(chunk, offset); offset += chunk.length; }
+  const base64url = btoa(String.fromCodePoint(...out))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
   const url = new URL(window.location.href);
-  url.search = "";
-  url.hash = "";
-  url.searchParams.set("share", encoded);
+  url.search = ""; url.hash = "";
+  url.searchParams.set("share", base64url);
   return url.toString();
 }
 
 // Decode a shared reading from the current URL's ?share= param
-export function decodeReadingFromUrl(): StoredReading | null {
-  const params = new URLSearchParams(window.location.search);
-  const encoded = params.get("share");
+export async function decodeReadingFromUrl(): Promise<StoredReading | null> {
+  const encoded = new URLSearchParams(window.location.search).get("share");
   if (!encoded) return null;
   try {
-    const json = decodeURIComponent(atob(encoded));
-    return JSON.parse(json) as StoredReading;
+    const padded = encoded.replace(/-/g, "+").replace(/_/g, "/")
+      + "==".slice(0, (4 - encoded.length % 4) % 4);
+    const bytes = Uint8Array.from(atob(padded), c => c.codePointAt(0)!);
+    const stream = new ReadableStream({
+      start(c) { c.enqueue(bytes); c.close(); },
+    });
+    const decompressed = stream.pipeThrough(new DecompressionStream("gzip"));
+    const chunks: Uint8Array[] = [];
+    const reader = decompressed.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+    let offset = 0;
+    for (const chunk of chunks) { out.set(chunk, offset); offset += chunk.length; }
+    return JSON.parse(new TextDecoder().decode(out)) as StoredReading;
   } catch {
     return null;
   }
@@ -218,6 +260,7 @@ export function useReadingStorage() {
       readingStorage.getReadingsByDateRange.bind(readingStorage),
     exportReadings: readingStorage.exportReadings.bind(readingStorage),
     importReadings: readingStorage.importReadings.bind(readingStorage),
+    importReading: readingStorage.importReading.bind(readingStorage),
     getStorageStats: readingStorage.getStorageStats.bind(readingStorage),
   };
 }


### PR DESCRIPTION
…tory

- Replace btoa(encodeURIComponent(json)) with gzip + URL-safe base64 in encodeReadingToUrl/decodeReadingFromUrl. The old double-encoding inflated URLs ~4x, likely exceeding Netlify CDN limits and causing the empty .txt download recipients saw instead of the app loading.
- Add ReadingStorage.importReading() to persist a shared reading into the recipient's localStorage history (deduplicated by ID).
- Update App.vue onMounted to await the async decode and call importReading, so shared readings appear in the recipient's history after opening a link.
- Update ReadingHistory.vue copyShareLink to await the now-async encode.

https://claude.ai/code/session_013GzbDvn7Dq2rP5DLUEUa7o

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
