### PR TITLE
fix follow-up errors and improve proxy CORS/error handling

### DIFF
--- a/netlify/functions/llm-proxy.ts
+++ b/netlify/functions/llm-proxy.ts
@@ -19,14 +19,6 @@ function isRateLimited(ip: string): boolean {
 }
 
 export const handler: Handler = async (event: HandlerEvent) => {
-  // Only allow POST requests
-  if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ error: 'Method not allowed' }),
-    };
-  }
-
   // Get the origin for CORS
   const origin = event.headers.origin || '';
 
@@ -39,6 +31,27 @@ export const handler: Handler = async (event: HandlerEvent) => {
 
   const isAllowedOrigin = allowedOrigins.includes(origin);
   const corsOrigin = isAllowedOrigin ? origin : '';
+
+  // Handle CORS preflight before any other checks
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: {
+        'Access-Control-Allow-Origin': corsOrigin,
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      },
+      body: '',
+    };
+  }
+
+  // Only allow POST requests
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
 
   if (!isAllowedOrigin && origin) {
     console.warn(`Blocked request from unauthorized origin: ${origin}`);
@@ -113,7 +126,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
           'Access-Control-Allow-Headers': 'Content-Type',
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ error: 'LLM provider error' }),
+        body: JSON.stringify({ error: data?.error?.message || 'LLM provider error' }),
       };
     }
 

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -100,8 +100,8 @@ const sendMessage = async () => {
   isLoading.value = true;
 
   try {
-    // Get conversation history (excluding the chart data message)
-    const history = messages.value.slice(1).map((msg) => ({
+    // Get conversation history (excluding the pending new message)
+    const history = messages.value.slice(0, -1).map((msg) => ({
       role: msg.role,
       content: msg.content,
     }));


### PR DESCRIPTION
- Chat.vue: change slice(1) to slice(0,-1) so conversation history includes the initial reading but excludes the pending user message. Previously, the current user message was included in history AND appended again by continueHoraryConversation, producing duplicate consecutive user messages that Groq rejects.

- llm-proxy: add OPTIONS preflight handler so CORS works for any cross-origin access (deploy previews, VPN exit nodes, etc.). Previously a 405 with no CORS headers was returned, blocking the browser before the real request could fire.

- llm-proxy: surface Groq's actual error message instead of the opaque 'LLM provider error', making regional/quota failures visible and debuggable.

https://claude.ai/code/session_016QChcjRrjfjE3cpbjN75ca

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
