### PR TITLE
Reorganize reading UI: unified tab bar in chat section

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -29,6 +29,7 @@ const currentMessage = ref("");
 const isLoading = ref(false);
 const hasInitialReading = ref(false);
 const conversationContainer = ref<HTMLElement>();
+const questionCollapsed = ref(false);
 
 // Format error message with actionable guidance
 function formatErrorMessage(error: any): string {
@@ -225,12 +226,16 @@ watch(() => props.reading, (newReading) => {
 <template>
   <div class="horary-conversation">
     <div class="conversation-header">
-      <h3>Horary Reading</h3>
-      <div class="question-info">
-        <p class="question">{{ questionInfo.question }}</p>
-        <p class="meta">
-          {{ questionInfo.time }} • {{ questionInfo.location }}
-        </p>
+      <button
+        @click="questionCollapsed = !questionCollapsed"
+        class="question-toggle"
+        :title="questionCollapsed ? 'Show question details' : 'Collapse question details'"
+      >
+        <span class="question-preview">{{ questionInfo.question }}</span>
+        <span class="question-chevron">{{ questionCollapsed ? '▼' : '▲' }}</span>
+      </button>
+      <div v-show="!questionCollapsed" class="question-meta">
+        <p class="meta">{{ questionInfo.time }} • {{ questionInfo.location }}</p>
       </div>
     </div>
 
@@ -313,7 +318,6 @@ watch(() => props.reading, (newReading) => {
   display: flex;
   flex-direction: column;
   height: 100%;
-  max-height: 80vh;
   background: var(--color-bg-secondary);
   border-radius: 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -321,27 +325,52 @@ watch(() => props.reading, (newReading) => {
 }
 
 .conversation-header {
-  padding: 1.5rem;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg-tertiary);
 }
 
-.conversation-header h3 {
-  margin: 0 0 0.5rem 0;
-  color: var(--color-text-primary);
-  font-size: 1.25rem;
-}
-
-.question-info .question {
-  font-style: italic;
+.question-toggle {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
   color: var(--color-text-secondary);
-  margin: 0.5rem 0;
-  font-size: 1rem;
+  font-size: 0.9rem;
+  font-style: italic;
+  transition: background-color 0.15s ease;
 }
 
-.question-info .meta {
+.question-toggle:hover {
+  background: var(--color-bg-hover);
+}
+
+.question-preview {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+}
+
+.question-chevron {
+  font-size: 0.65rem;
   color: var(--color-text-tertiary);
-  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
+.question-meta {
+  padding: 0 1rem 0.75rem;
+}
+
+.question-meta .meta {
+  color: var(--color-text-tertiary);
+  font-size: 0.8rem;
   margin: 0;
 }
 
@@ -627,10 +656,6 @@ watch(() => props.reading, (newReading) => {
 
 /* Mobile optimizations */
 @media (max-width: 640px) {
-  .conversation-header {
-    padding: 1rem;
-  }
-
   .conversation-container {
     padding: 0.75rem;
   }

--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, nextTick, watch, onMounted } from "vue";
+import { ref, nextTick, watch, onMounted, onUnmounted } from "vue";
 import { Chart } from "@astrodraw/astrochart";
 import QuestionForm from "./QuestionForm.vue";
 import HoraryChart from "./HoraryChart.vue";
@@ -30,14 +30,19 @@ const { saveReading, updateReading } = useReadingStorage();
 const chartData = ref<QuestionData | null>(null);
 const showConversation = ref(false);
 const currentReadingId = ref<string | null>(null);
-const activeTab = ref<'wheel' | 'data'>('wheel');
+const activeTab = ref<'chat' | 'wheel' | 'data'>('chat');
 const showAbout = ref(false);
+const isMobile = ref(window.innerWidth <= 768);
+
+const handleResize = () => {
+  isMobile.value = window.innerWidth <= 768;
+};
 
 const handleChartCalculated = async (data: QuestionData) => {
   chartData.value = data;
 
   showConversation.value = true;
-  activeTab.value = 'wheel'; // Start with chart wheel view
+  activeTab.value = 'chat'; // Start with chat tab
 
   // Save the new reading to storage
   try {
@@ -221,6 +226,14 @@ watch(
   { immediate: true }
 );
 
+onMounted(() => {
+  window.addEventListener('resize', handleResize);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize);
+});
+
 // Load selected reading on mount if provided
 onMounted(async () => {
   if (props.selectedReading) {
@@ -263,28 +276,11 @@ watch(activeTab, async (newTab) => {
       </div>
 
       <div v-else class="reading-layout">
-        <!-- Chart display -->
-        <div class="chart-section">
-          <!-- Tab Navigation -->
-          <div class="tab-navigation">
-            <button
-              @click="activeTab = 'wheel'"
-              :class="['tab-button', { active: activeTab === 'wheel' }]"
-            >
-              Chart Wheel
-            </button>
-            <button
-              @click="activeTab = 'data'"
-              :class="['tab-button', { active: activeTab === 'data' }]"
-            >
-              Chart Data
-            </button>
-          </div>
-
-          <!-- Tab Content -->
+        <!-- Chart display (desktop only — unmounted on mobile to avoid #paper conflict) -->
+        <div v-if="!isMobile" class="chart-section">
           <div class="tab-content">
-            <HoraryChart v-if="activeTab === 'wheel'" :chart-data="chartData" />
-            <ChartDataView v-if="activeTab === 'data'" :chart-data="chartData" />
+            <HoraryChart v-show="activeTab !== 'data'" :chart-data="chartData" />
+            <ChartDataView v-show="activeTab === 'data'" :chart-data="chartData" />
           </div>
 
           <div class="chart-actions">
@@ -299,7 +295,43 @@ watch(activeTab, async (newTab) => {
 
         <!-- Conversation interface -->
         <div v-if="showConversation" class="conversation-section">
+          <!-- Unified tab navigation -->
+          <div class="tab-navigation">
+            <button
+              @click="activeTab = 'chat'"
+              :class="['tab-button', { active: activeTab === 'chat' }]"
+            >
+              Chat
+            </button>
+            <button
+              @click="activeTab = 'wheel'"
+              :class="['tab-button', { active: activeTab === 'wheel' }]"
+            >
+              Chart Wheel
+            </button>
+            <button
+              @click="activeTab = 'data'"
+              :class="['tab-button', { active: activeTab === 'data' }]"
+            >
+              Chart Data
+            </button>
+          </div>
+
+          <!-- Mobile-only chart views (rendered here since chart-section is unmounted) -->
+          <template v-if="isMobile">
+            <HoraryChart v-if="activeTab === 'wheel'" :chart-data="chartData" />
+            <ChartDataView v-if="activeTab === 'data'" :chart-data="chartData" />
+            <div v-if="activeTab !== 'chat'" class="mobile-chart-actions">
+              <button @click="startNewReading" class="new-reading-button">
+                Ask Another Question
+              </button>
+              <span v-if="currentReadingId" class="reading-saved"> ✓ Reading saved </span>
+            </div>
+          </template>
+
+          <!-- Chat (always on desktop; only when chat tab active on mobile) -->
           <Chat
+            v-if="!isMobile || activeTab === 'chat'"
             :reading="chartData"
             :existing-conversation="selectedReading?.conversation || []"
             @conversation-update="handleConversationUpdate" />
@@ -568,9 +600,17 @@ watch(activeTab, async (newTab) => {
 .tab-navigation {
   display: flex;
   gap: 0.5rem;
-  margin-bottom: 1rem;
   border-bottom: 2px solid var(--color-border);
   padding-bottom: 0;
+}
+
+.mobile-chart-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  flex-wrap: wrap;
 }
 
 .tab-button {
@@ -601,6 +641,7 @@ watch(activeTab, async (newTab) => {
   min-height: 300px;
   overflow: hidden;
 }
+
 
 .input-area {
   position: sticky;
@@ -637,11 +678,15 @@ watch(activeTab, async (newTab) => {
 @media (max-width: 768px) {
   .reading-layout {
     grid-template-columns: 1fr;
-    gap: 1rem;
+    gap: 0;
   }
 
+  /* Remove the card container on mobile so chat fills the viewport edge-to-edge */
   .content-area {
-    padding: 0.75rem;
+    padding: 0;
+    border-radius: 0;
+    box-shadow: none;
+    background: transparent;
   }
 
   .welcome-message {
@@ -652,28 +697,11 @@ watch(activeTab, async (newTab) => {
     grid-template-columns: 1fr;
     gap: 1rem;
   }
-
-  .chart-section {
-    order: 2; /* Chart comes after conversation on mobile */
-  }
-
-  .conversation-section {
-    order: 1;
-  }
 }
 
 @media (max-width: 640px) {
-  .content-area {
-    padding: 0.5rem;
-    border-radius: 0.5rem;
-  }
-
   .reading-layout {
-    gap: 0.5rem;
-  }
-
-  .chart-section {
-    gap: 0.5rem;
+    gap: 0;
   }
 
   .chart-actions {


### PR DESCRIPTION
- Move Chart Wheel and Chart Data tabs from the left chart column into the conversation section, alongside a new Chat tab
- Remove the static "Horary Reading" h3 heading; replace with a collapsible question-preview toggle (shows question text + time/location)
- On desktop: chart section (left) stays always visible, tabs control whether it shows the wheel or data view; Chat is always shown on right
- On mobile: chart section is unmounted (avoiding #paper conflict); tabs in the conversation section switch between Chat, HoraryChart, and ChartDataView; chart actions (Ask Another Question) surface below chart
- Strip the .content-area card chrome on mobile (padding, border-radius, box-shadow) so the chat fills the full viewport width and height

https://claude.ai/code/session_017Mc66hEwipsiMqKqvZtWL5

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
