### PR TITLE
fix: mobile UI layout — overflow, text zoom, sticky tabs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -127,6 +127,11 @@ onMounted(async () => {
   box-sizing: border-box;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 /* CSS Custom Properties for Theming */
 :root {
   /* Light mode — warm parchment with gold/amber highlights */

--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -561,6 +561,7 @@ watch(activeTab, async (newTab) => {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
 }
 
 .new-reading-button {
@@ -687,6 +688,14 @@ watch(activeTab, async (newTab) => {
     border-radius: 0;
     box-shadow: none;
     background: transparent;
+  }
+
+  .tab-navigation {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: var(--color-bg-primary);
+    transition: background-color 0.3s ease;
   }
 
   .welcome-message {


### PR DESCRIPTION
- Add html { -webkit-text-size-adjust: 100% } to prevent iOS from inflating font sizes in narrow columns of text
- Add min-width: 0 to .conversation-section so it respects its CSS Grid cell width and stops overflowing the viewport horizontally
- Make .tab-navigation position: sticky on mobile so Chat / Chart Wheel / Chart Data tabs remain visible regardless of scroll position

https://claude.ai/code/session_014cMF2X9ma54YmKsGLTgfKD

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
