### PR TITLE
Fix mobile question text wrapping and show location name instead of coordinates

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -176,11 +176,10 @@ const questionInfo = computed(() => {
   return {
     question: props.reading.question,
     time: new Date(props.reading.timestamp).toLocaleString(),
-    location: props.reading.location
-      ? `${props.reading.location.latitude.toFixed(
-          2
-        )}°, ${props.reading.location.longitude.toFixed(2)}°`
-      : "Location not provided",
+    location: props.reading.locationName
+      || (props.reading.location
+        ? `${props.reading.location.latitude.toFixed(2)}°, ${props.reading.location.longitude.toFixed(2)}°`
+        : "Location not provided"),
   };
 });
 
@@ -352,9 +351,6 @@ watch(() => props.reading, (newReading) => {
 
 .question-preview {
   flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: var(--color-text-secondary);
 }
 

--- a/src/components/QuestionForm.vue
+++ b/src/components/QuestionForm.vue
@@ -9,6 +9,7 @@ interface QuestionData {
     latitude: number;
     longitude: number;
   };
+  locationName?: string;
   chartData: any;
 }
 
@@ -136,6 +137,7 @@ const handleSubmit = async () => {
       question: question.value,
       timestamp: questionTime.toISOString(),
       location: location.value,
+      locationName: locationName.value || undefined,
       chartData,
     };
 

--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -14,6 +14,7 @@ interface QuestionData {
     latitude: number;
     longitude: number;
   };
+  locationName?: string;
   chartData: any;
 }
 
@@ -50,6 +51,7 @@ const handleChartCalculated = async (data: QuestionData) => {
       question: data.question,
       timestamp: data.timestamp,
       location: data.location,
+      locationName: data.locationName,
       chartData: data.chartData,
       conversation: [],
     });
@@ -210,6 +212,7 @@ watch(
         question: newReading.question,
         timestamp: newReading.timestamp,
         location: newReading.location,
+        locationName: newReading.locationName,
         chartData: newReading.chartData,
       };
       showConversation.value = true;
@@ -241,6 +244,7 @@ onMounted(async () => {
       question: props.selectedReading.question,
       timestamp: props.selectedReading.timestamp,
       location: props.selectedReading.location,
+      locationName: props.selectedReading.locationName,
       chartData: props.selectedReading.chartData,
     };
     showConversation.value = true;

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -346,6 +346,7 @@ export interface HoraryReading {
     latitude: number;
     longitude: number;
   };
+  locationName?: string;
   chartData: HoraryChartData;
 }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -9,6 +9,7 @@ export interface StoredReading {
     latitude: number;
     longitude: number;
   };
+  locationName?: string;
   chartData: any;
   conversation: Array<{
     role: "user" | "assistant";


### PR DESCRIPTION
- Remove white-space/overflow/text-overflow from .question-preview so the full
  question wraps on narrow screens instead of being cut off with an ellipsis
- Add locationName field to StoredReading and HoraryReading interfaces
- QuestionForm now passes the reverse-geocoded place name (already fetched via
  Nominatim) through to storage and the Chat component
- Chat header displays "City, State, Country" when available, falling back to
  coordinates for older readings that pre-date this change

https://claude.ai/code/session_01FGEfJswSngtDXx6512Z3ye