### PR TITLE
Improve API error messages for non-technical users

### DIFF
--- a/netlify/functions/llm-proxy.ts
+++ b/netlify/functions/llm-proxy.ts
@@ -7,6 +7,37 @@ const rateLimitMap = new Map<string, { count: number; windowStart: number }>();
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 20;
 
+function humanizeGroqError(status: number, error?: { type?: string; code?: string; message?: string }): string {
+  const errorType = error?.type || '';
+  const errorCode = error?.code || '';
+
+  if (status === 401) {
+    return 'The AI service credentials are misconfigured. Please contact the developer.';
+  }
+  if (status === 403) {
+    return 'Access to this AI model is restricted. Please contact the developer.';
+  }
+  if (status === 404) {
+    return 'The requested AI model is unavailable right now. Please try again shortly.';
+  }
+  if (status === 413) {
+    return 'Your question is too long for the AI to process. Please shorten it and try again.';
+  }
+  if (status === 422) {
+    return 'Something about your question couldn\'t be processed. Try rephrasing it, and if it keeps happening, contact the developer.';
+  }
+  if (status === 429) {
+    if (errorType === 'tokens' || errorCode === 'rate_limit_exceeded' || errorType.includes('token')) {
+      return 'This shared AI service has used a lot of capacity recently — you\'re not the only one using it! Please wait a moment and try again.';
+    }
+    return 'This shared AI service is currently at capacity — you\'re not the only one using it! Please wait a moment and try again.';
+  }
+  if (status >= 500) {
+    return 'The AI service is temporarily unavailable. Please try again in a few minutes.';
+  }
+  return 'The AI service encountered an unexpected problem. Please try again shortly.';
+}
+
 function isRateLimited(ip: string): boolean {
   const now = Date.now();
   const entry = rateLimitMap.get(ip);
@@ -66,7 +97,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
     console.error('GROQ_FREE_TIER_KEY environment variable is not set');
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: 'Server configuration error' }),
+      body: JSON.stringify({ error: 'The service is not properly configured. Please contact the developer.' }),
     };
   }
 
@@ -82,7 +113,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
         'Access-Control-Allow-Origin': corsOrigin,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ error: 'Too many requests - please try again later' }),
+      body: JSON.stringify({ error: 'You\'ve made too many requests in a short time. Please wait a minute and try again.' }),
     };
   }
 
@@ -126,7 +157,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
           'Access-Control-Allow-Headers': 'Content-Type',
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ error: data?.error?.message || 'LLM provider error' }),
+        body: JSON.stringify({ error: humanizeGroqError(response.status, data?.error) }),
       };
     }
 
@@ -149,7 +180,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
         'Access-Control-Allow-Headers': 'Content-Type',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ error: 'Internal server error' }),
+      body: JSON.stringify({ error: 'Something went wrong on our end. Please try again shortly.' }),
     };
   }
 };

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -7,6 +7,7 @@ import {
   continueHoraryConversation,
   type HoraryReading,
 } from "../utils/llm";
+import { formatLLMError } from "../utils/llm/client";
 
 interface ConversationMessage {
   role: "user" | "assistant";
@@ -33,21 +34,7 @@ const questionCollapsed = ref(false);
 
 // Format error message with actionable guidance
 function formatErrorMessage(error: any): string {
-  const errorMessage = error?.message || String(error);
-
-  if (errorMessage.includes('Ollama server not running')) {
-    return `Unable to connect to Ollama server. Please ensure Ollama is running on your system. You can check your connection settings by clicking the settings button (⚙️) in the header.`;
-  }
-
-  if (errorMessage.includes('Model not found')) {
-    return `The selected model was not found. Please check your model settings by clicking the settings button (⚙️) in the header, or pull the model using the Ollama CLI.`;
-  }
-
-  if (errorMessage.includes('timeout')) {
-    return `Connection timeout. The Ollama server is not responding. Please check your settings (⚙️) or try increasing the timeout value.`;
-  }
-
-  return `Error: ${errorMessage}. Please check your Ollama settings (⚙️) and ensure the server is running.`;
+  return formatLLMError(error);
 }
 
 // Generate initial reading

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -459,7 +459,7 @@ export const generateHoraryReading = async (
     if (settings.provider === 'openrouter-free') {
       const quotaCheck = checkQuota();
       if (!quotaCheck.allowed) {
-        throw new Error(`Free tier limit reached: ${quotaCheck.reason}. Please add your own API key in Settings to continue.`);
+        throw new Error(quotaCheck.reason);
       }
     }
 
@@ -530,7 +530,7 @@ export const continueHoraryConversation = async (
     if (settings.provider === 'openrouter-free') {
       const quotaCheck = checkQuota();
       if (!quotaCheck.allowed) {
-        throw new Error(`Free tier limit reached: ${quotaCheck.reason}. Please add your own API key in Settings to continue.`);
+        throw new Error(quotaCheck.reason);
       }
     }
 
@@ -580,7 +580,7 @@ export const generateText = async (prompt: string): Promise<string | null> => {
     if (settings.provider === 'openrouter-free') {
       const quotaCheck = checkQuota();
       if (!quotaCheck.allowed) {
-        throw new Error(`Free tier limit reached: ${quotaCheck.reason}. Please add your own API key in Settings to continue.`);
+        throw new Error(quotaCheck.reason);
       }
     }
 

--- a/src/utils/llm/client.ts
+++ b/src/utils/llm/client.ts
@@ -72,16 +72,26 @@ export function formatLLMError(error: any, provider?: string): string {
   const errorMessage = error?.message || String(error);
   const activeProvider = provider || loadSettings().provider;
 
+  // Quota limit messages are already user-friendly — pass through as-is
+  if (errorMessage.includes('shared AI service has')) {
+    return errorMessage;
+  }
+
+  const isFreeTier = activeProvider === 'openrouter-free';
+
   // Connection errors
   if (errorMessage.includes('ECONNREFUSED') || errorMessage.includes('Failed to fetch')) {
     if (activeProvider === 'ollama') {
       return 'Cannot connect to Ollama server. Please ensure Ollama is running on your machine.';
     }
-    return 'Network connection failed. Please check your internet connection.';
+    return 'Couldn\'t reach the AI service. Please check your internet connection and try again.';
   }
 
   // API key errors
   if (errorMessage.includes('API key') || errorMessage.includes('apiKey') || errorMessage.includes('401')) {
+    if (isFreeTier) {
+      return 'The AI service credentials are misconfigured. Please contact the developer.';
+    }
     return `Invalid or missing API key. Please check your ${activeProvider.toUpperCase()} API key in Settings.`;
   }
 
@@ -90,19 +100,38 @@ export function formatLLMError(error: any, provider?: string): string {
     if (activeProvider === 'ollama') {
       return 'Model not found. Please pull the model using: ollama pull <model-name>';
     }
+    if (isFreeTier) {
+      return 'The requested AI model is unavailable right now. Please try again shortly.';
+    }
     return 'Model not found. Please check your model name in Settings.';
   }
 
   // Timeout errors
   if (errorMessage.includes('timeout') || errorMessage.includes('aborted')) {
+    if (isFreeTier) {
+      return 'The AI service took too long to respond. Please try again in a moment.';
+    }
     return 'Request timeout. The server took too long to respond. Try increasing timeout in Settings.';
   }
 
   // Rate limit errors
-  if (errorMessage.includes('429') || errorMessage.includes('rate limit')) {
+  if (errorMessage.includes('429') || errorMessage.includes('rate limit') || errorMessage.includes('at capacity')) {
+    if (isFreeTier) {
+      return 'This shared AI service is currently at capacity — you\'re not the only one using it! Please wait a moment and try again.';
+    }
     return 'Rate limit exceeded. Please wait a moment before trying again.';
   }
 
-  // Generic error with provider context
+  // Server errors
+  if (errorMessage.includes('500') || errorMessage.includes('502') || errorMessage.includes('503') || errorMessage.includes('unavailable')) {
+    if (isFreeTier) {
+      return 'The AI service is temporarily unavailable. Please try again in a few minutes.';
+    }
+  }
+
+  // Generic error — keep Ollama messages technical for developers, soften free-tier messages
+  if (isFreeTier) {
+    return 'The AI service encountered an unexpected problem. Please try again shortly.';
+  }
   return `Error from ${activeProvider.toUpperCase()}: ${errorMessage}`;
 }

--- a/src/utils/llm/freeTier.ts
+++ b/src/utils/llm/freeTier.ts
@@ -76,7 +76,7 @@ export function checkQuota(): { allowed: boolean; reason?: string } {
   if (usage.dailyTokensUsed >= limits.maxTokensPerDay) {
     return {
       allowed: false,
-      reason: `Daily token limit reached (${limits.maxTokensPerDay} tokens). Resets at midnight.`,
+      reason: 'The shared AI service has hit its daily limit. Please try again tomorrow, or add your own API key in Settings to continue without limits.',
     };
   }
 
@@ -87,7 +87,7 @@ export function checkQuota(): { allowed: boolean; reason?: string } {
 
     return {
       allowed: false,
-      reason: `Hourly request limit reached (${limits.maxRequestsPerHour} requests/hour). Try again in ${minutesUntilReset} minutes.`,
+      reason: `The shared AI service has reached its hourly limit. Please try again in ${minutesUntilReset} minute${minutesUntilReset === 1 ? '' : 's'}, or add your own API key in Settings to continue without limits.`,
     };
   }
 


### PR DESCRIPTION
Replace raw Groq/technical error strings with calm, plain-English messages that reassure users and guide them toward the right action:

- llm-proxy.ts: add humanizeGroqError() mapping all Groq HTTP status codes (401, 403, 404, 413, 422, 429, 5xx) to friendly user messages; emphasize that 429s are a shared-service issue, not necessarily the user's fault
- client.ts: update formatLLMError() to return soft free-tier messages instead of exposing technical strings; add passthrough for already-friendly quota messages
- freeTier.ts: rewrite checkQuota() reason strings to explain the shared pool context and offer the Settings API key as a self-serve escape hatch
- llm.ts: throw quota reason directly instead of wrapping in technical prefix
- Chat.vue: delegate formatErrorMessage() to formatLLMError() from client.ts so error handling is provider-aware and not hardcoded to Ollama

https://claude.ai/code/session_01BNXXHN9xeiK7oenCB3yPa2

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
