### PR TITLE
rename openrouter-free to groq-free, set Qwen as default for personal API key

### DIFF
--- a/src/components/LLMSettings.vue
+++ b/src/components/LLMSettings.vue
@@ -52,7 +52,7 @@ const usageStats = computed(() => {
   // Depend on usageStatsVersion to trigger re-computation
   usageStatsVersion.value; // eslint-disable-line no-unused-expressions
 
-  if (localProvider.value === 'openrouter-free') {
+  if (localProvider.value === 'groq-free') {
     return getUsageStats();
   }
   return null;
@@ -85,7 +85,7 @@ watch(localProvider, (newProvider) => {
   if (newProvider === 'ollama') {
     localBaseUrl.value = 'http://localhost:11434/v1/';
     localApiKey.value = '';
-  } else if (newProvider === 'openrouter-free') {
+  } else if (newProvider === 'groq-free') {
     localApiKey.value = '';
     localBaseUrl.value = '';
   } else if (newProvider === 'groq') {
@@ -257,7 +257,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Free Tier Usage Stats -->
-        <div v-if="localProvider === 'openrouter-free' && usageStats" class="usage-stats">
+        <div v-if="localProvider === 'groq-free' && usageStats" class="usage-stats">
           <h3>Usage This Period</h3>
           <div class="usage-stat">
             <span class="stat-label">Hourly Requests:</span>
@@ -450,7 +450,7 @@ onUnmounted(() => {
           </p>
         </div>
 
-        <div v-else-if="localProvider === 'openrouter-free'" class="help-section">
+        <div v-else-if="localProvider === 'groq-free'" class="help-section">
           <h4 style="margin-top: 0; color: var(--color-text-primary);">Free Tier with Groq</h4>
           <p class="form-help">
             Try the app with Groq's lightning-fast free tier using our shared API key:

--- a/src/composables/useLLMSettings.ts
+++ b/src/composables/useLLMSettings.ts
@@ -41,7 +41,7 @@ async function testProviderConnection(
           error: `Server responded with status ${response.status}`,
         };
       }
-    } else if (provider === 'openrouter-free') {
+    } else if (provider === 'groq-free') {
       // Test free tier by checking if Netlify function is available
       const baseURL = import.meta.env.DEV
         ? 'http://localhost:8888/.netlify/functions'

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -1,4 +1,4 @@
-export type LLMProvider = 'ollama' | 'openrouter-free' | 'groq';
+export type LLMProvider = 'ollama' | 'groq-free' | 'groq';
 
 export interface BaseLLMSettings {
   provider: LLMProvider;
@@ -12,7 +12,7 @@ export interface OllamaProviderSettings {
 }
 
 export interface FreeTierProviderSettings {
-  provider: 'openrouter-free';
+  provider: 'groq-free';
   mode: 'free-tier';
   model: string;
   timeout: number;
@@ -73,8 +73,8 @@ export const PROVIDER_CONFIGS: Record<LLMProvider, ProviderConfig> = {
     defaultModel: 'llama3.2:latest',
     suggestedModels: ['llama3.2:latest', 'qwen2.5:14b', 'mistral:latest'],
   },
-  'openrouter-free': {
-    id: 'openrouter-free',
+  'groq-free': {
+    id: 'groq-free',
     name: 'Free Tier (Groq)',
     description: 'Try the app with Groq\'s free tier. Fast responses with generous limits.',
     requiresApiKey: false,
@@ -93,13 +93,12 @@ export const PROVIDER_CONFIGS: Record<LLMProvider, ProviderConfig> = {
     description: 'Use your own Groq API key for personal limits — no sharing with other users.',
     requiresApiKey: true,
     supportsLocal: false,
-    defaultModel: 'llama-3.3-70b-versatile',
+    defaultModel: 'qwen/qwen3-32b',
     suggestedModels: [
+      'qwen/qwen3-32b',
+      'qwen-2.5-32b',
       'llama-3.3-70b-versatile',
-      'llama-3.1-70b-versatile',
       'llama-3.1-8b-instant',
-      'gemma2-9b-it',
-      'mixtral-8x7b-32768',
     ],
     apiKeyPlaceholder: 'gsk_...',
     apiKeyPattern: /^gsk_/,

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -23,6 +23,6 @@ export function canUseOllama(): boolean {
 /**
  * Gets the default provider based on the current environment
  */
-export function getDefaultProvider(): 'ollama' | 'openrouter-free' {
-  return isLocalDevelopment() ? 'ollama' : 'openrouter-free';
+export function getDefaultProvider(): 'ollama' | 'groq-free' {
+  return isLocalDevelopment() ? 'ollama' : 'groq-free';
 }

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -457,7 +457,7 @@ export const generateHoraryReading = async (
     const settings = loadSettings();
 
     // Check quota if using free tier
-    if (settings.provider === 'openrouter-free') {
+    if (settings.provider === 'groq-free') {
       const quotaCheck = checkQuota();
       if (!quotaCheck.allowed) {
         throw new Error(quotaCheck.reason);
@@ -505,7 +505,7 @@ Begin your response immediately with "## Overall Judgment" — no preamble.`;
     });
 
     // Record usage for free tier
-    if (settings.provider === 'openrouter-free') {
+    if (settings.provider === 'groq-free') {
       const tokensUsed = response.usage?.total_tokens || 0;
       recordUsage(tokensUsed);
     }
@@ -528,7 +528,7 @@ export const continueHoraryConversation = async (
     const settings = loadSettings();
 
     // Check quota if using free tier
-    if (settings.provider === 'openrouter-free') {
+    if (settings.provider === 'groq-free') {
       const quotaCheck = checkQuota();
       if (!quotaCheck.allowed) {
         throw new Error(quotaCheck.reason);
@@ -559,7 +559,7 @@ export const continueHoraryConversation = async (
     });
 
     // Record usage for free tier
-    if (settings.provider === 'openrouter-free') {
+    if (settings.provider === 'groq-free') {
       const tokensUsed = response.usage?.total_tokens || 0;
       recordUsage(tokensUsed);
     }
@@ -578,7 +578,7 @@ export const generateText = async (prompt: string): Promise<string | null> => {
     const settings = loadSettings();
 
     // Check quota if using free tier
-    if (settings.provider === 'openrouter-free') {
+    if (settings.provider === 'groq-free') {
       const quotaCheck = checkQuota();
       if (!quotaCheck.allowed) {
         throw new Error(quotaCheck.reason);
@@ -594,7 +594,7 @@ export const generateText = async (prompt: string): Promise<string | null> => {
     });
 
     // Record usage for free tier
-    if (settings.provider === 'openrouter-free') {
+    if (settings.provider === 'groq-free') {
       const tokensUsed = response.usage?.total_tokens || 0;
       recordUsage(tokensUsed);
     }

--- a/src/utils/llm/client.ts
+++ b/src/utils/llm/client.ts
@@ -73,7 +73,7 @@ export function createLLMClient(settings?: LLMSettings): OpenAI {
     case 'ollama':
       return createOllamaClient(activeSettings);
 
-    case 'openrouter-free':
+    case 'groq-free':
       return createFreeTierClient();
 
     case 'groq':
@@ -104,7 +104,7 @@ export function formatLLMError(error: any, provider?: string): string {
     return errorMessage;
   }
 
-  const isFreeTier = activeProvider === 'openrouter-free';
+  const isFreeTier = activeProvider === 'groq-free';
   const isGroq = activeProvider === 'groq';
 
   // Connection errors

--- a/src/utils/llm/environment.ts
+++ b/src/utils/llm/environment.ts
@@ -25,8 +25,8 @@ export function getDefaultProvider(): LLMProvider {
     return 'ollama';
   }
 
-  // In deployed environment, default to OpenRouter (has free models)
-  return 'openrouter-free';
+  // In deployed environment, default to Groq free tier
+  return 'groq-free';
 }
 
 /**
@@ -38,7 +38,7 @@ export function isProviderAvailable(provider: LLMProvider): boolean {
     return isLocalEnvironment();
   }
 
-  // OpenRouter and Anthropic work everywhere
+  // Groq providers work everywhere
   return true;
 }
 
@@ -50,5 +50,5 @@ export function getEnvironmentGuidance(): string {
     return 'You are running locally. Ollama (free, private) is recommended.';
   }
 
-  return 'You are on a deployed site. Please use OpenRouter or Anthropic (requires API key).';
+  return 'You are on a deployed site. Please use the Groq free tier or your own API key.';
 }

--- a/src/utils/llm/storage.ts
+++ b/src/utils/llm/storage.ts
@@ -20,9 +20,9 @@ export function getDefaultSettings(provider: LLMProvider): LLMSettings {
         timeout: DEFAULT_TIMEOUT,
       };
 
-    case 'openrouter-free':
+    case 'groq-free':
       return {
-        provider: 'openrouter-free',
+        provider: 'groq-free',
         mode: 'free-tier',
         model: config.defaultModel,
         timeout: DEFAULT_TIMEOUT,
@@ -84,11 +84,11 @@ export function loadSettings(): LLMSettings {
 
       // Validate: Ollama can only be used in local development
       if (parsed.provider === 'ollama' && !canUseOllama()) {
-        console.warn('Ollama cannot be used on deployed sites. Switching to OpenRouter.');
+        console.warn('Ollama cannot be used on deployed sites. Switching to Groq free tier.');
         // Switch to OpenRouter and save the change
-        const openrouterSettings = getDefaultSettings('openrouter-free');
-        saveSettings(openrouterSettings);
-        return openrouterSettings;
+        const groqFreeSettings = getDefaultSettings('groq-free');
+        saveSettings(groqFreeSettings);
+        return groqFreeSettings;
       }
 
       // For groq: ensure apiKey field exists (may be missing from older stored settings)
@@ -117,10 +117,10 @@ export function loadSettings(): LLMSettings {
     if (migrated) {
       // Also validate migrated settings
       if (migrated.provider === 'ollama' && !canUseOllama()) {
-        console.warn('Ollama cannot be used on deployed sites. Switching to OpenRouter.');
-        const openrouterSettings = getDefaultSettings('openrouter-free');
-        saveSettings(openrouterSettings);
-        return openrouterSettings;
+        console.warn('Ollama cannot be used on deployed sites. Switching to Groq free tier.');
+        const groqFreeSettings = getDefaultSettings('groq-free');
+        saveSettings(groqFreeSettings);
+        return groqFreeSettings;
       }
       return migrated;
     }


### PR DESCRIPTION
- Rename provider ID 'openrouter-free' -> 'groq-free' throughout codebase
  (the provider never used OpenRouter; it has always proxied to Groq)
- Unify model lists: groq personal-key provider now uses the same
  suggested models as groq-free (Qwen first, then Llama)
- Set defaultModel for the 'groq' provider to 'qwen/qwen3-32b'
- Users with previously saved groq models not in the new list will
  be automatically reset to qwen/qwen3-32b on next load (existing
  validation logic in storage.ts handles this)