### PR TITLE
refactor: consolidate color system into new token architecture with candlelight dark mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -145,57 +145,85 @@ html {
 
 /* CSS Custom Properties for Theming */
 :root {
-  /* Light mode — warm parchment with gold/amber highlights */
-  --color-bg-primary: #fdf8f0;
-  --color-bg-secondary: #fffcf5;
-  --color-bg-tertiary: #fdf1dc;
-  --color-bg-hover: #f5e6c0;
-  --color-bg-active: #d97706;
+  /* Light mode — warm parchment, aged ink, gold highlights */
 
+  /* Main page background — old vellum parchment */
+  --color-bg: #fdf6e8;
+  /* Card / panel background — slightly deeper manuscript page */
+  --color-surface: #faf0d8;
+  /* Elevated surfaces — dropdowns, modals, raised panels */
+  --color-surface-raised: #f4e4be;
+
+  /* Main body text — dark brown ink */
   --color-text-primary: #2d1f0e;
+  /* Supporting / secondary text — medium brown */
   --color-text-secondary: #6b4c2a;
-  --color-text-tertiary: #9a7148;
-  --color-text-inverse: #fffcf5;
+  /* Placeholders, disabled states, timestamps — light brown */
+  --color-text-muted: #9a7148;
 
-  --color-border: #e8d5a8;
-  --color-border-focus: #c9a84c;
+  /* Dividers and input borders — warm tan */
+  --color-border: #ddc896;
 
-  --color-accent: #d97706;
-  --color-accent-hover: #b45309;
-  --color-success: #65a30d;
-  --color-warning: #f59e0b;
-  --color-error: #dc2626;
+  /* Primary action color — rich amber-gold */
+  --color-accent: #b8690a;
+  /* Accent on hover / active state */
+  --color-accent-hover: #96550a;
+  /* Text and icons placed on top of the accent color */
+  --color-accent-foreground: #fffcf5;
 
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+  /* Internal-use tokens (not in the public token spec) */
+  --color-bg-hover: #ecddb0;           /* hover state for interactive surfaces */
+  --color-bg-active: #b8690a;          /* active nav / selected state bg */
+  --color-text-inverse: #fffcf5;       /* light text on dark/accent backgrounds */
+  --color-border-focus: #c09030;       /* focus ring — warm gold */
+  --color-success: #4a8c12;
+  --color-warning: #d97706;
+  --color-error: #c52020;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.12);
 }
 
-/* Dark mode — brownish black with cream text, gold and forest green */
+/* Dark mode — candlelight in a dark overgrown stairwell */
+/* Palette drawn from deep forest foliage, dark wood, and candleflame amber */
 :root.dark {
-  --color-bg-primary: #1a0e05;
-  --color-bg-secondary: #261507;
-  --color-bg-tertiary: #3d2010;
-  --color-bg-hover: #522b14;
-  --color-bg-active: #b45309;
+  /* Main page background — near-black deep forest, like the darkest foliage */
+  --color-bg: #0e1a10;
+  /* Card / panel background — dark mid-foliage, shadowed wood */
+  --color-surface: #182b1a;
+  /* Elevated surfaces — slightly lighter canopy layer */
+  --color-surface-raised: #223424;
 
-  --color-text-primary: #fdf4dc;
-  --color-text-secondary: #e8d5b0;
-  --color-text-tertiary: #c4a882;
-  --color-text-inverse: #1a0e05;
+  /* Main body text — soft candle-wax cream */
+  --color-text-primary: #f2e8d0;
+  /* Supporting text — warmer cream with a hint of amber */
+  --color-text-secondary: #c8b896;
+  /* Placeholders, disabled, timestamps — warm muted tan */
+  --color-text-muted: #8a7a5c;
 
-  --color-border: #6b3d0f;
-  --color-border-focus: #a0591c;
+  /* Dividers and input borders — shadowed greenery */
+  --color-border: #2d4430;
 
-  --color-accent: #f59e0b;
-  --color-accent-hover: #d97706;
-  --color-success: #2d6a4f;
-  --color-warning: #d97706;
-  --color-error: #f87171;
+  /* Primary action color — candleflame amber */
+  --color-accent: #d4820a;
+  /* Accent on hover / active state — deeper ember */
+  --color-accent-hover: #b86d08;
+  /* Text and icons placed on top of the accent color */
+  --color-accent-foreground: #1a0d02;
 
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.4);
+  /* Internal-use tokens */
+  --color-bg-hover: #243826;           /* hover state — slightly brighter foliage */
+  --color-bg-active: #d4820a;          /* active nav — candleflame */
+  --color-text-inverse: #0e1a10;       /* dark text on light/accent backgrounds */
+  --color-border-focus: #a06820;       /* focus ring — warm amber-gold */
+  --color-success: #2a6a3a;
+  --color-warning: #d4820a;
+  --color-error: #e06060;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 2px 6px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.55);
 }
 
 body {
@@ -203,7 +231,7 @@ body {
     Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   color: var(--color-text-primary);
-  background-color: var(--color-bg-primary);
+  background-color: var(--color-bg);
   overflow-x: hidden;
   transition: background-color 0.3s ease, color 0.3s ease;
 }
@@ -219,7 +247,7 @@ body {
 
 /* Header */
 .app-header {
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-surface);
   padding: 1rem;
   box-shadow: var(--shadow-sm);
   position: sticky;
@@ -253,7 +281,7 @@ body {
 
 .info-tag {
   background: rgba(217, 119, 6, 0.08);
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   border: 1px solid rgba(217, 119, 6, 0.2);
   border-radius: 9999px;
   font-size: 0.6875rem;
@@ -284,7 +312,7 @@ body {
 }
 
 .nav-button {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
   padding: 0.5rem 1rem;
@@ -325,7 +353,7 @@ body {
 
 /* Settings Button */
 .settings-button {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   padding: 0.5rem;
@@ -351,7 +379,7 @@ body {
 /* Feedback Button */
 .feedback-button {
   background: rgba(217, 119, 6, 0.08);
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   border: 1px solid rgba(217, 119, 6, 0.2);
   border-radius: 9999px;
   font-size: 0.6875rem;
@@ -372,7 +400,7 @@ body {
 
 /* Dark Mode Toggle */
 .dark-mode-toggle {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   padding: 0.5rem;

--- a/src/components/ChartDataView.vue
+++ b/src/components/ChartDataView.vue
@@ -547,7 +547,7 @@ const formatTimeToExact = (days: number | undefined) => {
 
 <style scoped>
 .chart-data-view {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 1rem;
   padding: 1.5rem;
   overflow-y: auto;
@@ -578,7 +578,7 @@ const formatTimeToExact = (days: number | undefined) => {
   padding: 0.4rem 0.9rem;
   border-radius: 0.375rem;
   border: 1px solid var(--color-border-focus);
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-secondary);
   font-size: 0.8rem;
   cursor: pointer;
@@ -609,7 +609,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .timestamp, .location {
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   font-size: 0.85rem;
   margin: 0.25rem 0;
 }
@@ -648,7 +648,7 @@ const formatTimeToExact = (days: number | undefined) => {
   padding: 0.2rem 0.6rem;
   border: 1px solid var(--color-border-focus);
   border-radius: 0.25rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-secondary);
   cursor: pointer;
   white-space: nowrap;
@@ -665,7 +665,7 @@ const formatTimeToExact = (days: number | undefined) => {
 .data-table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   overflow: hidden;
@@ -673,7 +673,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .data-table thead {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
 }
 
 .data-table th {
@@ -698,7 +698,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .data-table tbody tr:hover {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
 }
 
 /* Planet Table */
@@ -750,7 +750,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .aspect-highlight {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 0.5rem;
   padding: 1rem;
   border: 1px solid var(--color-border);
@@ -777,7 +777,7 @@ const formatTimeToExact = (days: number | undefined) => {
 
 .orb {
   font-family: monospace;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
 }
@@ -818,7 +818,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .no-aspect {
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   font-style: italic;
   margin: 0;
 }
@@ -877,7 +877,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .past-time {
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
 }
 
 /* Houses Grid */
@@ -888,7 +888,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .house-item {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   padding: 0.75rem;
@@ -930,7 +930,7 @@ const formatTimeToExact = (days: number | undefined) => {
   color: var(--color-text-secondary);
   margin-left: 0.5rem;
   padding: 0.25rem 0.5rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.25rem;
 }
 
@@ -968,7 +968,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .dignity-score.neutral {
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
 }
 
 /* Row coloring by strength */
@@ -1130,7 +1130,7 @@ const formatTimeToExact = (days: number | undefined) => {
   padding: 1.5rem;
   border-radius: 0.5rem;
   border: 2px solid;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
 }
 
 .voc-status.voc-warning {
@@ -1243,7 +1243,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .pof-dispositor {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 0.5rem;
   padding: 1rem;
   margin-bottom: 1rem;
@@ -1332,7 +1332,7 @@ const formatTimeToExact = (days: number | undefined) => {
 }
 
 .dispositor-dignity .dignity-score.neutral {
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
 }
 
 .dispositor-description {

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -325,7 +325,7 @@ watch(() => props.reading, (newReading) => {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   overflow: hidden;
@@ -333,7 +333,7 @@ watch(() => props.reading, (newReading) => {
 
 .conversation-header {
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
 }
 
 .question-toggle {
@@ -364,7 +364,7 @@ watch(() => props.reading, (newReading) => {
 
 .question-chevron {
   font-size: 0.65rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   flex-shrink: 0;
 }
 
@@ -373,7 +373,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .question-meta .meta {
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   font-size: 0.8rem;
   margin: 0;
 }
@@ -536,7 +536,7 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message.assistant .message-text {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   color: var(--color-text-primary);
   border-radius: 0;
   padding-left: 0;
@@ -551,7 +551,7 @@ watch(() => props.reading, (newReading) => {
 
 .message-time {
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   margin-top: 0.25rem;
   align-self: flex-end;
 }
@@ -565,7 +565,7 @@ watch(() => props.reading, (newReading) => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 0;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border: none;
   border-radius: 0;
 }
@@ -609,7 +609,7 @@ watch(() => props.reading, (newReading) => {
 .conversation-input {
   padding: 1rem;
   border-top: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
 }
 
 .input-container {
@@ -629,7 +629,7 @@ watch(() => props.reading, (newReading) => {
   max-height: 120px;
   overflow-y: auto;
   transition: border-color 0.2s ease;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   color: var(--color-text-primary);
 }
 
@@ -639,8 +639,8 @@ watch(() => props.reading, (newReading) => {
 }
 
 .message-input:disabled {
-  background: var(--color-bg-tertiary);
-  color: var(--color-text-tertiary);
+  background: var(--color-surface-raised);
+  color: var(--color-text-muted);
 }
 
 .send-button {
@@ -696,7 +696,7 @@ watch(() => props.reading, (newReading) => {
   margin-top: 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   font-size: 0.875rem;
 }
 
@@ -748,7 +748,7 @@ details[open] .followup-guide-toggle::before {
   margin-top: 0.5rem !important;
   font-style: italic;
   font-size: 0.8rem;
-  color: var(--color-text-tertiary) !important;
+  color: var(--color-text-muted) !important;
   border-top: 1px solid var(--color-border);
   padding-top: 0.5rem;
 }

--- a/src/components/FeedbackModal.vue
+++ b/src/components/FeedbackModal.vue
@@ -162,7 +162,7 @@ async function submit() {
 }
 
 .modal {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   width: 100%;
@@ -191,7 +191,7 @@ async function submit() {
 .modal-close {
   background: none;
   border: none;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 1rem;
   padding: 0.25rem 0.5rem;
@@ -230,7 +230,7 @@ async function submit() {
   margin-left: auto;
   font-size: 0.75rem;
   font-weight: 400;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
 }
 
 .form-input,
@@ -240,7 +240,7 @@ async function submit() {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   color: var(--color-text-primary);
   font-size: 0.875rem;
   font-family: inherit;
@@ -301,7 +301,7 @@ async function submit() {
 }
 
 .btn-secondary {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;

--- a/src/components/HoraryInfoModal.vue
+++ b/src/components/HoraryInfoModal.vue
@@ -62,7 +62,7 @@ const close = () => emit('update:modelValue', false);
 }
 
 .modal {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 0.75rem;
   max-width: 520px;
   width: 100%;
@@ -121,7 +121,7 @@ const close = () => emit('update:modelValue', false);
 .tradition-note {
   padding-top: 0.75rem;
   border-top: 1px solid var(--color-border);
-  color: var(--color-text-tertiary) !important;
+  color: var(--color-text-muted) !important;
   font-size: 0.875rem !important;
 }
 </style>

--- a/src/components/LLMSettings.vue
+++ b/src/components/LLMSettings.vue
@@ -519,7 +519,7 @@ onUnmounted(() => {
 }
 
 .modal {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 0.75rem;
   max-width: 600px;
   width: 100%;
@@ -585,7 +585,7 @@ onUnmounted(() => {
   border: 2px solid var(--color-border);
   border-radius: 0.5rem;
   font-size: 1rem;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   color: var(--color-text-primary);
   transition: border-color 0.2s;
 }
@@ -602,12 +602,12 @@ onUnmounted(() => {
 
 .form-help {
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   margin: 0;
 }
 
 .form-help code {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
   font-family: monospace;
@@ -634,7 +634,7 @@ onUnmounted(() => {
 }
 
 .toggle-visibility-button {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border: 2px solid var(--color-border);
   padding: 0.75rem;
   border-radius: 0.5rem;
@@ -663,7 +663,7 @@ onUnmounted(() => {
 }
 
 .refresh-button {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border: 2px solid var(--color-border);
   padding: 0.75rem;
   border-radius: 0.5rem;
@@ -703,7 +703,7 @@ onUnmounted(() => {
   flex-direction: column;
   gap: 0.75rem;
   padding: 1rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.5rem;
 }
 
@@ -765,7 +765,7 @@ onUnmounted(() => {
 
 .help-section {
   padding: 1rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.5rem;
   border: 1px solid var(--color-border);
 }
@@ -804,7 +804,7 @@ onUnmounted(() => {
 }
 
 .cancel-button {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
   padding: 0.5rem 1rem;
@@ -840,7 +840,7 @@ onUnmounted(() => {
 /* Free tier usage stats */
 .usage-stats {
   padding: 1rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.5rem;
   border: 1px solid var(--color-border);
 }

--- a/src/components/QuestionForm.vue
+++ b/src/components/QuestionForm.vue
@@ -236,7 +236,7 @@ onMounted(() => {
 <style scoped>
 .question-form-container {
   width: 100%;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s ease;
@@ -271,7 +271,7 @@ textarea {
   min-height: 44px;
   max-height: 120px;
   overflow-y: auto;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   color: var(--color-text-primary);
 }
 
@@ -299,7 +299,7 @@ textarea.error {
 
 .char-counter {
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   margin-top: 0.25rem;
   margin-left: auto;
 }
@@ -334,7 +334,7 @@ textarea.error {
 
 .submit-button:disabled {
   background-color: var(--color-bg-hover);
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   cursor: not-allowed;
 }
 
@@ -359,7 +359,7 @@ textarea.error {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.5rem;
   border: 1px solid var(--color-border);
 }
@@ -381,7 +381,7 @@ textarea.error {
   border: 2px solid var(--color-border);
   border-radius: 0.5rem;
   font-size: 1rem;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   color: var(--color-text-primary);
   transition: border-color 0.2s ease;
 }
@@ -393,7 +393,7 @@ textarea.error {
 
 .field-hint {
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   font-style: italic;
 }
 
@@ -402,7 +402,7 @@ textarea.error {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   color: var(--color-text-secondary);
@@ -423,7 +423,7 @@ textarea.error {
 
 .location-coords {
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   font-family: monospace;
 }
 

--- a/src/components/ReadingHistory.vue
+++ b/src/components/ReadingHistory.vue
@@ -277,7 +277,7 @@ onMounted(loadReadings);
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 1rem;
   overflow: hidden;
 }
@@ -285,7 +285,7 @@ onMounted(loadReadings);
 .history-header {
   padding: 1.5rem;
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
 }
 
 .header-top {
@@ -327,7 +327,7 @@ onMounted(loadReadings);
   border-radius: 0.5rem;
   font-size: 1rem;
   transition: border-color 0.2s;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   color: var(--color-text-primary);
 }
 
@@ -391,7 +391,7 @@ onMounted(loadReadings);
 }
 
 .reading-card {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   padding: 1rem;
@@ -413,7 +413,7 @@ onMounted(loadReadings);
 
 .reading-time {
   font-size: 0.875rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   font-weight: 500;
 }
 
@@ -468,7 +468,7 @@ onMounted(loadReadings);
   display: flex;
   gap: 1rem;
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
 }
 
 .conversation-count {
@@ -497,7 +497,7 @@ onMounted(loadReadings);
 }
 
 .modal {
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 0.75rem;
   padding: 1.5rem;
   max-width: 400px;
@@ -523,7 +523,7 @@ onMounted(loadReadings);
 }
 
 .cancel-button {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
   padding: 0.5rem 1rem;

--- a/src/components/UserChat.vue
+++ b/src/components/UserChat.vue
@@ -411,7 +411,7 @@ watch(activeTab, async (newTab) => {
   min-height: 0;
   overflow-y: auto;
   padding: 1rem;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface);
   border-radius: 1rem;
   box-shadow: var(--shadow-md);
   width: 100%;
@@ -447,7 +447,7 @@ watch(activeTab, async (newTab) => {
   align-items: flex-start;
   gap: 1rem;
   padding: 1rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.75rem;
   border: 1px solid var(--color-border);
   transition: background-color 0.3s ease, border-color 0.3s ease;
@@ -492,7 +492,7 @@ watch(activeTab, async (newTab) => {
 }
 
 .about-toggle:hover {
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   color: var(--color-text-primary);
 }
 
@@ -515,7 +515,7 @@ watch(activeTab, async (newTab) => {
 
 .about-card {
   padding: 1rem;
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
   border-radius: 0.75rem;
   border: 1px solid var(--color-border);
 }
@@ -624,7 +624,7 @@ watch(activeTab, async (newTab) => {
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
   font-weight: 500;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-muted);
   cursor: pointer;
   border-bottom: 2px solid transparent;
   margin-bottom: -2px;
@@ -633,7 +633,7 @@ watch(activeTab, async (newTab) => {
 
 .tab-button:hover {
   color: var(--color-text-primary);
-  background: var(--color-bg-tertiary);
+  background: var(--color-surface-raised);
 }
 
 .tab-button.active {
@@ -651,7 +651,7 @@ watch(activeTab, async (newTab) => {
 .input-area {
   position: sticky;
   bottom: 0;
-  background: var(--color-bg-primary);
+  background: var(--color-bg);
   padding: 1rem 0;
   margin-top: auto;
   width: 100%;
@@ -698,7 +698,7 @@ watch(activeTab, async (newTab) => {
     position: sticky;
     top: 0;
     z-index: 5;
-    background: var(--color-bg-primary);
+    background: var(--color-bg);
     transition: background-color 0.3s ease;
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -3,10 +3,6 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,11 +11,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-accent);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-accent-hover);
 }
 
 body {
@@ -40,12 +36,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-surface-raised);
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-accent);
 }
 button:focus,
 button:focus-visible {
@@ -60,17 +56,4 @@ button:focus-visible {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
Replaces the old ad-hoc CSS variable names with a clean, spec-compliant
token system. Dark mode palette is redesigned from scratch using the
attached reference photo (dark overgrown stairwell with candles):

New token names (light → dark):
- --color-bg: main page background (#fdf6e8 → #0e1a10 deep forest)
- --color-surface: card/panel background (#faf0d8 → #182b1a mid-foliage)
- --color-surface-raised: elevated surfaces (#f4e4be → #223424 canopy)
- --color-text-primary: body text (#2d1f0e → #f2e8d0 candle-wax cream)
- --color-text-secondary: supporting text (#6b4c2a → #c8b896)
- --color-text-muted: placeholders/disabled (#9a7148 → #8a7a5c warm tan)
- --color-border: dividers/inputs (#ddc896 → #2d4430 shadowed greenery)
- --color-accent: primary action (#b8690a → #d4820a candleflame amber)
- --color-accent-hover: hover state (#96550a → #b86d08 deep ember)
- --color-accent-foreground: text on accent (#fffcf5 → #1a0d02)

Renames across all components (no functional changes):
  --color-bg-primary → --color-bg
  --color-bg-secondary → --color-surface
  --color-bg-tertiary → --color-surface-raised
  --color-text-tertiary → --color-text-muted

Also strips the Vite default hardcoded colors from style.css,
replacing them with CSS variable references.

https://claude.ai/code/session_01U7WsTXVzgvuKPT1UxtMn3i