### PR TITLE
fix dark mode color adaptation on iOS Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,17 @@
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#FFD700" />
+    <script>
+      (function () {
+        var stored = localStorage.getItem('darkMode');
+        var dark = stored !== null
+          ? stored === 'true'
+          : window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (dark) document.documentElement.classList.add('dark');
+      })();
+    </script>
     <meta
       name="description"
       content="Ask horary astrology questions and get readings" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -196,6 +196,7 @@ html {
 
 /* CSS Custom Properties for Theming */
 :root {
+  color-scheme: light;
   /* Light mode — warm parchment, aged ink, gold highlights */
 
   /* Main page background — old vellum parchment */
@@ -239,6 +240,7 @@ html {
 /* Dark mode — candlelight in a dark garden */
 /* Near-black green-tinted backgrounds with warm amber accents */
 :root.dark {
+  color-scheme: dark;
   /* Main page background — near-black green-tinted */
   --color-bg: #161a12;
   /* Card / panel background — dark surface */


### PR DESCRIPTION
Add color-scheme declarations to prevent Safari's automatic dark mode adaptation from turning parchment backgrounds into lavender and amber buttons into blue:

- color-scheme: light on :root — tells Safari not to auto-adapt light mode
- color-scheme: dark on :root.dark — tells Safari the app handles dark mode
- <meta name="color-scheme" content="light dark"> in index.html
- Inline script in <head> applies .dark class before first paint, preventing a FOUC window where Safari could snapshot and adapt the light parchment

https://claude.ai/code/session_01JUjHHBiA6bn5CMi2AbEWXo

## Summary
<!--
What changed and why? Bullet points are fine.
-->
-

## Test plan
- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual verification (describe steps if applicable)

## Notes
<!-- Anything reviewers / the auto-merge workflow should know -->
