### PR TITLE
Add secure screenshot upload to feedback modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,13 @@
 GROQ_FREE_TIER_KEY=gsk_your-key-here
 
 # GitHub Personal Access Token for feedback → GitHub Issues
-# Needs: public_repo scope (classic PAT) or Issues: write (fine-grained PAT)
+# Needs: public_repo scope (classic PAT) or Issues: write + Contents: write (fine-grained PAT)
+# The Contents: write scope is required to upload screenshot attachments
 # Create at: https://github.com/settings/tokens
 GITHUB_TOKEN=ghp_your-token-here
 
 # Target repo for feedback issues (defaults to aditiohri/horary if unset)
 # GITHUB_REPO=aditiohri/horary
+
+# Branch to commit feedback screenshots to (defaults to main if unset)
+# GITHUB_BRANCH=main

--- a/netlify/functions/feedback.ts
+++ b/netlify/functions/feedback.ts
@@ -2,6 +2,77 @@ import type { Handler, HandlerEvent } from '@netlify/functions';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPO = process.env.GITHUB_REPO || 'aditiohri/horary';
+const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'main';
+
+const ALLOWED_IMAGE_TYPES: Record<string, string> = {
+  'image/jpeg': 'jpeg',
+  'image/png':  'png',
+  'image/gif':  'gif',
+  'image/webp': 'webp',
+};
+
+// 1 MB pre-encoding cap; base64 inflates by ~33%, so cap base64 string at ceil(1MB * 4/3)
+const MAX_BASE64_LENGTH = Math.ceil(1024 * 1024 * (4 / 3)) + 4;
+
+function validateImageMagicBytes(buf: Buffer, mimeType: string): boolean {
+  if (mimeType === 'image/jpeg') {
+    return buf[0] === 0xFF && buf[1] === 0xD8 && buf[2] === 0xFF;
+  }
+  if (mimeType === 'image/png') {
+    return (
+      buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4E && buf[3] === 0x47 &&
+      buf[4] === 0x0D && buf[5] === 0x0A && buf[6] === 0x1A && buf[7] === 0x0A
+    );
+  }
+  if (mimeType === 'image/gif') {
+    return (
+      buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 &&
+      buf[3] === 0x38 && (buf[4] === 0x37 || buf[4] === 0x39) && buf[5] === 0x61
+    );
+  }
+  if (mimeType === 'image/webp') {
+    return (
+      buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+      buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+    );
+  }
+  return false;
+}
+
+async function uploadImageToGitHub(
+  owner: string,
+  repo: string,
+  base64: string,
+  extension: string,
+  timestamp: string,
+): Promise<string | null> {
+  // Build path entirely from server-controlled values — never from user-supplied filename
+  const hash = Buffer.from(base64.slice(0, 64)).toString('hex').slice(0, 8);
+  const path = `feedback-images/${timestamp}-${hash}.${extension}`;
+
+  const ghRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `token ${GITHUB_TOKEN}`,
+      'Accept': 'application/vnd.github.v3+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'horary-feedback-bot',
+    },
+    body: JSON.stringify({
+      message: `Add feedback screenshot ${timestamp}`,
+      content: base64,
+      branch: GITHUB_BRANCH,
+    }),
+  });
+
+  if (!ghRes.ok) {
+    const err = await ghRes.json().catch(() => ({}));
+    console.error('GitHub Contents API error:', ghRes.status, err);
+    return null;
+  }
+
+  return `https://raw.githubusercontent.com/${owner}/${repo}/${GITHUB_BRANCH}/${path}`;
+}
 
 // Rate limiter: 5 submissions per IP per hour
 const rateLimitMap = new Map<string, { count: number; windowStart: number }>();
@@ -90,7 +161,8 @@ export const handler: Handler = async (event: HandlerEvent) => {
     };
   }
 
-  let body: { type?: string; title?: string; body?: string };
+  interface ImagePayload { base64: string; mimeType: string; }
+  let body: { type?: string; title?: string; body?: string; image?: ImagePayload };
   try {
     body = JSON.parse(event.body || '{}');
   } catch {
@@ -109,6 +181,45 @@ export const handler: Handler = async (event: HandlerEvent) => {
     return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Details must be 2000 characters or fewer.' }) };
   }
 
+  const [owner, repo] = GITHUB_REPO.split('/');
+
+  // Optional image validation and upload
+  let imageMarkdown = '';
+  if (body.image) {
+    const { base64, mimeType } = body.image;
+
+    if (!ALLOWED_IMAGE_TYPES[mimeType]) {
+      return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid image type.' }) };
+    }
+    if (typeof base64 !== 'string' || base64.length > MAX_BASE64_LENGTH) {
+      return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Image exceeds 1 MB limit.' }) };
+    }
+    // Validate base64 charset before decoding
+    if (!/^[A-Za-z0-9+/]+=*$/.test(base64)) {
+      return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid image data.' }) };
+    }
+
+    let buf: Buffer;
+    try {
+      buf = Buffer.from(base64, 'base64');
+    } catch {
+      return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid image data.' }) };
+    }
+
+    if (!validateImageMagicBytes(buf, mimeType)) {
+      return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Image content does not match declared type.' }) };
+    }
+
+    const extension = ALLOWED_IMAGE_TYPES[mimeType];
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const rawUrl = await uploadImageToGitHub(owner, repo, base64, extension, timestamp);
+    if (rawUrl) {
+      imageMarkdown = `\n\n## Screenshot\n\n![Screenshot](${rawUrl})`;
+    } else {
+      console.error('Image upload failed; submitting issue without screenshot');
+    }
+  }
+
   const feedbackType = type as FeedbackType;
   const issueBody = [
     `## Feedback submitted via horary-chat.netlify.app`,
@@ -119,9 +230,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
     ``,
     `---`,
     `*Submitted: ${new Date().toISOString()}*`,
-  ].join('\n');
-
-  const [owner, repo] = GITHUB_REPO.split('/');
+  ].join('\n') + imageMarkdown;
   const ghResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
     method: 'POST',
     headers: {

--- a/src/components/FeedbackModal.vue
+++ b/src/components/FeedbackModal.vue
@@ -19,8 +19,55 @@ const state = ref<ModalState>('idle');
 const errorMessage = ref('');
 const issueUrl = ref('');
 
+const imageFile = ref<File | null>(null);
+const imagePreviewUrl = ref<string>('');
+const imageError = ref<string>('');
+const fileInputRef = ref<HTMLInputElement | null>(null);
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_BYTES = 1 * 1024 * 1024; // 1 MB
+
 function close() {
   emit('update:modelValue', false);
+}
+
+function onFileChange(event: Event) {
+  imageError.value = '';
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    imageError.value = 'Only JPEG, PNG, GIF, and WebP images are allowed.';
+    input.value = '';
+    return;
+  }
+  if (file.size > MAX_BYTES) {
+    imageError.value = 'Image must be 1 MB or smaller.';
+    input.value = '';
+    return;
+  }
+  imageFile.value = file;
+  imagePreviewUrl.value = URL.createObjectURL(file);
+}
+
+function removeImage() {
+  imageFile.value = null;
+  if (imagePreviewUrl.value) URL.revokeObjectURL(imagePreviewUrl.value);
+  imagePreviewUrl.value = '';
+  imageError.value = '';
+  if (fileInputRef.value) fileInputRef.value.value = '';
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      resolve(dataUrl.split(',')[1]);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
 }
 
 // Reset form after modal closes
@@ -33,6 +80,7 @@ watch(() => props.modelValue, (open) => {
       state.value = 'idle';
       errorMessage.value = '';
       issueUrl.value = '';
+      removeImage();
     }, 300);
   }
 });
@@ -45,6 +93,18 @@ async function submit() {
   state.value = 'submitting';
   errorMessage.value = '';
 
+  let imagePayload: { base64: string; mimeType: string } | undefined;
+  if (imageFile.value) {
+    try {
+      const base64 = await fileToBase64(imageFile.value);
+      imagePayload = { base64, mimeType: imageFile.value.type };
+    } catch {
+      errorMessage.value = 'Failed to read the image file. Please try again.';
+      state.value = 'error';
+      return;
+    }
+  }
+
   try {
     const response = await fetch('/.netlify/functions/feedback', {
       method: 'POST',
@@ -53,6 +113,7 @@ async function submit() {
         type: feedbackType.value,
         title: title.value.trim(),
         body: details.value.trim(),
+        ...(imagePayload && { image: imagePayload }),
       }),
     });
     const data = await response.json();
@@ -132,6 +193,38 @@ async function submit() {
               rows="5"
               :disabled="state === 'submitting'"
             />
+          </div>
+
+          <div class="form-group">
+            <label>
+              Screenshot
+              <span class="char-count">optional</span>
+            </label>
+            <div v-if="!imageFile" class="file-drop-zone">
+              <input
+                ref="fileInputRef"
+                id="feedback-image"
+                type="file"
+                accept="image/jpeg,image/png,image/gif,image/webp"
+                class="file-input-hidden"
+                :disabled="state === 'submitting'"
+                @change="onFileChange"
+              />
+              <label for="feedback-image" class="file-drop-label" :class="{ disabled: state === 'submitting' }">
+                Attach a screenshot (JPEG, PNG, GIF, WebP · max 1 MB)
+              </label>
+            </div>
+            <div v-else class="image-preview">
+              <img :src="imagePreviewUrl" alt="Screenshot preview" class="preview-img" />
+              <button
+                type="button"
+                class="remove-image"
+                :disabled="state === 'submitting'"
+                @click="removeImage"
+                aria-label="Remove image"
+              >✕</button>
+            </div>
+            <p v-if="imageError" class="form-error image-error">{{ imageError }}</p>
           </div>
 
           <p v-if="errorMessage" class="form-error">{{ errorMessage }}</p>
@@ -363,5 +456,81 @@ async function submit() {
 
 .success-sub a:hover {
   text-decoration: underline;
+}
+
+.file-drop-zone {
+  position: relative;
+}
+
+.file-input-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.file-drop-label {
+  display: block;
+  padding: 0.625rem 0.75rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.file-drop-label:not(.disabled):hover {
+  border-color: var(--color-border-focus);
+  color: var(--color-text-secondary);
+}
+
+.file-drop-label.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.image-preview {
+  position: relative;
+  display: inline-flex;
+}
+
+.preview-img {
+  max-width: 100%;
+  max-height: 10rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-border);
+  object-fit: contain;
+  display: block;
+}
+
+.remove-image {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: rgba(0, 0, 0, 0.55);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 1.375rem;
+  height: 1.375rem;
+  font-size: 0.6875rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.remove-image:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.image-error {
+  margin-top: 0.375rem;
+  margin-bottom: 0;
 }
 </style>


### PR DESCRIPTION
Users can now optionally attach a screenshot (JPEG, PNG, GIF, WebP, max 1 MB)
to their feedback submissions.

Security measures:
- Client-side: MIME type whitelist, 1 MB size cap, blob URL preview (no data URI)
- Server-side: MIME whitelist, base64 length cap, charset regex, magic byte
  validation (JPEG FF D8 FF, PNG 89 50 4E 47..., GIF 47 49 46 38..., WebP RIFF...WEBP)
- File path built entirely server-side from timestamp + content hash — user-supplied
  filename is never used in the path, preventing path injection
- Image uploaded to feedback-images/ in the GitHub repo via Contents API; the
  resulting raw.githubusercontent.com URL (served with CSP: default-src 'none')
  is embedded as a markdown image in the GitHub issue body
- Upload failure is non-fatal: issue is still created without the screenshot

https://claude.ai/code/session_0167zAjxFEy2GoMHfYBPoXtj