### PR TITLE
Always display an error code on every LLM error message

### DIFF
--- a/netlify/functions/llm-proxy.ts
+++ b/netlify/functions/llm-proxy.ts
@@ -7,46 +7,47 @@ const rateLimitMap = new Map<string, { count: number; windowStart: number }>();
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 20;
 
-function humanizeGroqError(status: number, isUserKey: boolean, error?: { type?: string; code?: string; message?: string }): string {
+function humanizeGroqError(status: number, isUserKey: boolean, error?: { type?: string; code?: string; message?: string }): { message: string; code: string | null } {
   const errorType = error?.type || '';
+  const code = error?.code ?? null;
 
   if (status === 401) {
     if (isUserKey) {
-      return 'Your Groq API key was rejected. Please double-check it in Settings and try again.';
+      return { message: 'Your Groq API key was rejected. Please double-check it in Settings and try again.', code };
     }
-    return 'The AI service credentials are misconfigured. Please contact the developer.';
+    return { message: 'The AI service credentials are misconfigured. Please contact the developer.', code };
   }
   if (status === 403) {
     if (isUserKey) {
-      return 'Your Groq API key doesn\'t have permission to use this model. Try a different model or check your Groq account.';
+      return { message: 'Your Groq API key doesn\'t have permission to use this model. Try a different model or check your Groq account.', code };
     }
-    return 'Access to this AI model is restricted. Please contact the developer.';
+    return { message: 'Access to this AI model is restricted. Please contact the developer.', code };
   }
   if (status === 404) {
-    return 'The requested AI model is unavailable right now. Please try again shortly.';
+    return { message: 'The requested AI model is unavailable right now. Please try again shortly.', code };
   }
   if (status === 413) {
-    return 'Your question is too long for the AI to process. Please shorten it and try again.';
+    return { message: 'Your question is too long for the AI to process. Please shorten it and try again.', code };
   }
   if (status === 422) {
-    return 'Something about your question couldn\'t be processed. Try rephrasing it, and if it keeps happening, contact the developer.';
+    return { message: 'Something about your question couldn\'t be processed. Try rephrasing it, and if it keeps happening, contact the developer.', code };
   }
   if (status === 429) {
     if (isUserKey) {
-      return 'You\'ve hit your personal Groq rate limit. Please wait a moment and try again.';
+      return { message: 'You\'ve hit your personal Groq rate limit. Please wait a moment and try again.', code };
     }
     if (errorType === 'tokens' || errorType.includes('token')) {
-      return 'This shared AI service has used a lot of capacity recently — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.';
+      return { message: 'This shared AI service has used a lot of capacity recently — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.', code };
     }
-    return 'This shared AI service is currently at capacity — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.';
+    return { message: 'This shared AI service is currently at capacity — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.', code };
   }
   if (status === 400) {
-    return 'The request was invalid — it may be too long or contain an unsupported parameter. Try a shorter question, or contact the developer if this persists.';
+    return { message: 'The request was invalid — it may be too long or contain an unsupported parameter. Try a shorter question, or contact the developer if this persists.', code };
   }
   if (status >= 500) {
-    return 'The AI service is temporarily unavailable. Please try again in a few minutes.';
+    return { message: 'The AI service is temporarily unavailable. Please try again in a few minutes.', code };
   }
-  return 'The AI service encountered an unexpected problem. Please try again shortly.';
+  return { message: 'The AI service encountered an unexpected problem. Please try again shortly.', code };
 }
 
 function isRateLimited(ip: string): boolean {
@@ -215,7 +216,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
         'Access-Control-Allow-Headers': 'Content-Type',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ error: 'Something went wrong on our end. Please try again shortly.' }),
+      body: JSON.stringify({ error: { message: 'Something went wrong on our end. Please try again shortly.', code: null } }),
     };
   }
 };

--- a/src/utils/__tests__/llmProviders.test.ts
+++ b/src/utils/__tests__/llmProviders.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { getProviderConfig, validateApiKey } from '../llmProviders';
+
+describe('getProviderConfig', () => {
+  it('returns ollama config with requiresApiKey: false', () => {
+    const config = getProviderConfig('ollama');
+    expect(config.id).toBe('ollama');
+    expect(config.name).toContain('Ollama');
+    expect(config.requiresApiKey).toBe(false);
+  });
+
+  it('returns groq-free config with requiresApiKey: false', () => {
+    const config = getProviderConfig('groq-free');
+    expect(config.id).toBe('groq-free');
+    expect(config.requiresApiKey).toBe(false);
+  });
+
+  it('returns groq config with requiresApiKey: true and a key pattern', () => {
+    const config = getProviderConfig('groq');
+    expect(config.id).toBe('groq');
+    expect(config.requiresApiKey).toBe(true);
+    expect(config.apiKeyPattern).toBeDefined();
+  });
+});
+
+describe('validateApiKey', () => {
+  it('returns valid for ollama regardless of key value (no key required)', () => {
+    expect(validateApiKey('ollama', '')).toEqual({ valid: true });
+    expect(validateApiKey('ollama', 'anything')).toEqual({ valid: true });
+  });
+
+  it('returns valid for groq-free regardless of key value (no key required)', () => {
+    expect(validateApiKey('groq-free', '')).toEqual({ valid: true });
+  });
+
+  it('returns invalid when groq API key is empty', () => {
+    const result = validateApiKey('groq', '');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('API key is required');
+  });
+
+  it('returns invalid when groq API key does not start with gsk_', () => {
+    const result = validateApiKey('groq', 'sk_notvalid');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('gsk_');
+  });
+
+  it('returns valid for a correctly formatted groq API key', () => {
+    expect(validateApiKey('groq', 'gsk_abc123XYZ')).toEqual({ valid: true });
+  });
+});

--- a/src/utils/llm/__tests__/formatLLMError.test.ts
+++ b/src/utils/llm/__tests__/formatLLMError.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { formatLLMError } from '../client';
+
+/** Build a minimal error object with optional status and code */
+function makeError(message: string, opts: { status?: number; code?: string | null } = {}): any {
+  return { message, status: opts.status, code: opts.code };
+}
+
+describe('formatLLMError — error code display (withCode)', () => {
+  it('appends the Groq error code when error.code is a non-empty string', () => {
+    const error = makeError('rate limit hit', { status: 429, code: 'rate_limit_exceeded' });
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('[rate_limit_exceeded]');
+    expect(result).not.toContain('[HTTP');
+  });
+
+  it('falls back to HTTP status when error.code is null', () => {
+    const error = makeError('429 You hit your rate limit', { status: 429, code: null });
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('[HTTP 429]');
+    expect(result).not.toContain('[no error code provided]');
+  });
+
+  it('appends [no error code provided] when neither code nor status is present', () => {
+    const error = makeError('Something weird happened with no HTTP context');
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('[no error code provided]');
+  });
+
+  it('uses the error code rather than the HTTP status when both are present', () => {
+    const error = makeError('some error', { status: 500, code: 'internal_server_error' });
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('[internal_server_error]');
+    expect(result).not.toContain('[HTTP 500]');
+  });
+});
+
+describe('formatLLMError — quota pass-through', () => {
+  it('passes through the daily quota message and appends [no error code provided]', () => {
+    const msg = 'The shared AI service has hit its daily limit. Please try again tomorrow, or add your own free Groq API key in Settings → LLM Provider.';
+    const result = formatLLMError(new Error(msg), 'groq-free');
+    expect(result).toContain('shared AI service has hit its daily limit');
+    expect(result).toContain('[no error code provided]');
+  });
+
+  it('passes through the hourly quota message and appends [no error code provided]', () => {
+    const msg = 'The shared AI service has reached its hourly limit. Please try again in 5 minutes, or add your own free Groq API key in Settings → LLM Provider.';
+    const result = formatLLMError(new Error(msg), 'groq-free');
+    expect(result).toContain('hourly limit');
+    expect(result).toContain('[no error code provided]');
+  });
+});
+
+describe('formatLLMError — connection errors', () => {
+  it('returns Ollama-specific message on ECONNREFUSED', () => {
+    const error = makeError('connect ECONNREFUSED 127.0.0.1:11434');
+    const result = formatLLMError(error, 'ollama');
+    expect(result).toContain('Ollama');
+    expect(result).toContain('running');
+  });
+
+  it('returns generic connectivity message on Failed to fetch for groq-free', () => {
+    const error = makeError('Failed to fetch');
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('internet connection');
+  });
+
+  it('returns generic connectivity message on Failed to fetch for groq', () => {
+    const error = makeError('Failed to fetch');
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('internet connection');
+    expect(result).toContain('[no error code provided]');
+  });
+});
+
+describe('formatLLMError — API key errors', () => {
+  it('returns key-rejected message for groq provider on 401', () => {
+    const error = makeError('401 Unauthorized', { status: 401 });
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('API key was rejected');
+    expect(result).toContain('[HTTP 401]');
+  });
+
+  it('returns misconfigured message for groq-free on 401', () => {
+    const error = makeError('401 Unauthorized', { status: 401 });
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('misconfigured');
+  });
+
+  it('returns provider-prefixed message for unknown provider on API key error', () => {
+    const error = makeError('API key missing');
+    const result = formatLLMError(error, 'ollama');
+    // ollama API key error → generic provider message
+    expect(result).toContain('OLLAMA');
+    expect(result).toContain('API key');
+  });
+});
+
+describe('formatLLMError — model not found', () => {
+  it('returns ollama pull instruction for Ollama on model not found', () => {
+    const error = makeError('model not found');
+    const result = formatLLMError(error, 'ollama');
+    expect(result).toContain('ollama pull');
+  });
+
+  it('returns unavailable message for groq on 404', () => {
+    const error = makeError('404 Not Found', { status: 404 });
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('unavailable');
+  });
+
+  it('returns unavailable message for groq-free on 404', () => {
+    const error = makeError('404 Not Found', { status: 404 });
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('unavailable');
+  });
+});
+
+describe('formatLLMError — timeout errors', () => {
+  it('returns timeout message for groq-free on "timeout" in message', () => {
+    const error = makeError('Request timeout after 30000ms', { status: 408 });
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('too long');
+  });
+
+  it('returns timeout message for groq on aborted request', () => {
+    const error = makeError('The user aborted a request.');
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('too long');
+  });
+
+  it('returns generic timeout message for ollama', () => {
+    const error = makeError('Request timeout after 30000ms');
+    const result = formatLLMError(error, 'ollama');
+    expect(result).toContain('timeout');
+    expect(result).toContain('Settings');
+  });
+});
+
+describe('formatLLMError — rate limit errors', () => {
+  it('returns personal rate limit message for groq on 429', () => {
+    const error = makeError('429 rate limit exceeded', { status: 429 });
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('personal Groq rate limit');
+  });
+
+  it('returns shared capacity message for groq-free on "at capacity"', () => {
+    const error = makeError('This service is at capacity', { status: 429 });
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('shared AI service');
+    expect(result).toContain('capacity');
+  });
+});
+
+describe('formatLLMError — server errors', () => {
+  it('returns temporarily unavailable message on 500 for groq-free', () => {
+    const error = makeError('500 Internal Server Error', { status: 500 });
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('temporarily unavailable');
+  });
+
+  it('returns temporarily unavailable message on 503 for groq', () => {
+    const error = makeError('503 Service Unavailable', { status: 503 });
+    const result = formatLLMError(error, 'groq');
+    expect(result).toContain('temporarily unavailable');
+  });
+});
+
+describe('formatLLMError — generic fallback', () => {
+  it('returns unexpected-problem message with code for groq-free on unmatched error', () => {
+    const error = makeError('An unusual glitch occurred');
+    const result = formatLLMError(error, 'groq-free');
+    expect(result).toContain('unexpected problem');
+    expect(result).toContain('[no error code provided]');
+  });
+
+  it('returns raw provider prefix for Ollama on unmatched error (developer-facing)', () => {
+    const error = makeError('some low-level model error');
+    const result = formatLLMError(error, 'ollama');
+    expect(result).toContain('Error from OLLAMA:');
+    expect(result).toContain('some low-level model error');
+  });
+});

--- a/src/utils/llm/__tests__/freeTier.test.ts
+++ b/src/utils/llm/__tests__/freeTier.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getFreeTierLimits,
+  loadFreeTierUsage,
+  saveFreeTierUsage,
+  checkQuota,
+  recordUsage,
+  getUsageStats,
+  resetUsage,
+} from '../freeTier';
+import type { FreeTierUsage } from '../../../types/llm';
+
+const STORAGE_KEY = 'free_tier_usage';
+
+/** Seed localStorage with a FreeTierUsage, defaulting to clean state for today */
+function seed(overrides: Partial<FreeTierUsage> = {}): void {
+  const today = new Date().toISOString().split('T')[0];
+  const defaults: FreeTierUsage = {
+    tokensUsed: 0,
+    requestCount: 0,
+    lastRequestTime: 0,
+    dailyTokensUsed: 0,
+    hourlyRequestCount: 0,
+    lastResetDate: today,
+    lastHourReset: Date.now(),
+    ...overrides,
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(defaults));
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.useRealTimers());
+
+// ---------------------------------------------------------------------------
+// getFreeTierLimits
+// ---------------------------------------------------------------------------
+describe('getFreeTierLimits', () => {
+  it('returns 10_000_000 daily token limit', () => {
+    expect(getFreeTierLimits().maxTokensPerDay).toBe(10_000_000);
+  });
+
+  it('returns 10 hourly request limit', () => {
+    expect(getFreeTierLimits().maxRequestsPerHour).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadFreeTierUsage
+// ---------------------------------------------------------------------------
+describe('loadFreeTierUsage', () => {
+  it('returns zero-state defaults when localStorage is empty', () => {
+    const usage = loadFreeTierUsage();
+    expect(usage.dailyTokensUsed).toBe(0);
+    expect(usage.hourlyRequestCount).toBe(0);
+    expect(usage.tokensUsed).toBe(0);
+    expect(usage.requestCount).toBe(0);
+  });
+
+  it('preserves counters when date and hour are unchanged', () => {
+    seed({ dailyTokensUsed: 500, hourlyRequestCount: 3 });
+    const usage = loadFreeTierUsage();
+    expect(usage.dailyTokensUsed).toBe(500);
+    expect(usage.hourlyRequestCount).toBe(3);
+  });
+
+  it('resets dailyTokensUsed when the date has changed', () => {
+    seed({ dailyTokensUsed: 5000, lastResetDate: '2000-01-01' });
+    const usage = loadFreeTierUsage();
+    expect(usage.dailyTokensUsed).toBe(0);
+  });
+
+  it('resets hourlyRequestCount when more than an hour has passed', () => {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    seed({ hourlyRequestCount: 7, lastHourReset: twoHoursAgo });
+    const usage = loadFreeTierUsage();
+    expect(usage.hourlyRequestCount).toBe(0);
+  });
+
+  it('does not reset hourly counter when less than an hour has passed', () => {
+    const thirtyMinsAgo = Date.now() - 30 * 60 * 1000;
+    seed({ hourlyRequestCount: 4, lastHourReset: thirtyMinsAgo });
+    const usage = loadFreeTierUsage();
+    expect(usage.hourlyRequestCount).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkQuota
+// ---------------------------------------------------------------------------
+describe('checkQuota', () => {
+  it('returns { allowed: true } when well within limits', () => {
+    seed({ dailyTokensUsed: 100, hourlyRequestCount: 2 });
+    expect(checkQuota()).toEqual({ allowed: true });
+  });
+
+  it('returns { allowed: true } when storage is empty', () => {
+    expect(checkQuota()).toEqual({ allowed: true });
+  });
+
+  it('blocks when dailyTokensUsed equals the daily limit', () => {
+    seed({ dailyTokensUsed: 10_000_000 });
+    const result = checkQuota();
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('daily limit');
+  });
+
+  it('blocks when hourlyRequestCount equals the hourly limit', () => {
+    seed({ hourlyRequestCount: 10 });
+    const result = checkQuota();
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('hourly limit');
+  });
+
+  it('includes correct minutes-until-reset in the hourly block reason', () => {
+    const fixedNow = new Date('2024-06-15T12:30:00.000Z').getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+
+    const thirtyMinsAgo = fixedNow - 30 * 60 * 1000;
+    seed({ hourlyRequestCount: 10, lastHourReset: thirtyMinsAgo });
+
+    const result = checkQuota();
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('30 minute');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordUsage
+// ---------------------------------------------------------------------------
+describe('recordUsage', () => {
+  it('increments all usage counters by the given token count', () => {
+    seed({ tokensUsed: 100, dailyTokensUsed: 50, requestCount: 2, hourlyRequestCount: 1 });
+    recordUsage(200);
+    const usage = loadFreeTierUsage();
+    expect(usage.tokensUsed).toBe(300);
+    expect(usage.dailyTokensUsed).toBe(250);
+    expect(usage.requestCount).toBe(3);
+    expect(usage.hourlyRequestCount).toBe(2);
+  });
+
+  it('updates lastRequestTime to approximately now', () => {
+    const before = Date.now();
+    seed();
+    recordUsage(100);
+    const usage = loadFreeTierUsage();
+    expect(usage.lastRequestTime).toBeGreaterThanOrEqual(before);
+  });
+
+  it('dispatches a free-tier-usage-updated CustomEvent on window', () => {
+    seed();
+    const spy = vi.fn();
+    window.addEventListener('free-tier-usage-updated', spy);
+    recordUsage(500);
+    window.removeEventListener('free-tier-usage-updated', spy);
+    expect(spy).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUsageStats
+// ---------------------------------------------------------------------------
+describe('getUsageStats', () => {
+  it('calculates dailyTokensRemaining as limit minus used', () => {
+    seed({ dailyTokensUsed: 1_000_000 });
+    const stats = getUsageStats();
+    expect(stats.dailyTokensRemaining).toBe(9_000_000);
+    expect(stats.dailyTokensUsed).toBe(1_000_000);
+  });
+
+  it('clamps dailyTokensRemaining to zero when usage exceeds limit', () => {
+    seed({ dailyTokensUsed: 11_000_000 });
+    const stats = getUsageStats();
+    expect(stats.dailyTokensRemaining).toBe(0);
+  });
+
+  it('calculates hourlyRequestsRemaining correctly', () => {
+    seed({ hourlyRequestCount: 6 });
+    const stats = getUsageStats();
+    expect(stats.hourlyRequestsRemaining).toBe(4);
+    expect(stats.hourlyRequestsUsed).toBe(6);
+  });
+
+  it('reports totalTokensUsed and totalRequests from the usage object', () => {
+    seed({ tokensUsed: 42_000, requestCount: 17 });
+    const stats = getUsageStats();
+    expect(stats.totalTokensUsed).toBe(42_000);
+    expect(stats.totalRequests).toBe(17);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resetUsage
+// ---------------------------------------------------------------------------
+describe('resetUsage', () => {
+  it('sets all counters to zero', () => {
+    seed({ tokensUsed: 5000, dailyTokensUsed: 3000, hourlyRequestCount: 8, requestCount: 15 });
+    resetUsage();
+    const usage = loadFreeTierUsage();
+    expect(usage.tokensUsed).toBe(0);
+    expect(usage.dailyTokensUsed).toBe(0);
+    expect(usage.hourlyRequestCount).toBe(0);
+    expect(usage.requestCount).toBe(0);
+  });
+
+  it('allows quota again after reset even when previously over both limits', () => {
+    seed({ dailyTokensUsed: 10_000_000, hourlyRequestCount: 10 });
+    expect(checkQuota().allowed).toBe(false);
+    resetUsage();
+    expect(checkQuota()).toEqual({ allowed: true });
+  });
+});

--- a/src/utils/llm/__tests__/freeTier.test.ts
+++ b/src/utils/llm/__tests__/freeTier.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getFreeTierLimits,
   loadFreeTierUsage,
-  saveFreeTierUsage,
   checkQuota,
   recordUsage,
   getUsageStats,

--- a/src/utils/llm/__tests__/storage.test.ts
+++ b/src/utils/llm/__tests__/storage.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DEFAULT_TIMEOUT, PROVIDER_CONFIGS } from '../../../types/llm';
+
+// Mock the environment module so we can control canUseOllama() / getDefaultProvider()
+// without depending on window.location.hostname in jsdom.
+vi.mock('../../environment', () => ({
+  canUseOllama: vi.fn(() => true),       // default: local dev
+  getDefaultProvider: vi.fn(() => 'ollama'), // default: local dev
+}));
+
+// Import after mock setup so storage.ts picks up the mocked module
+import { getDefaultSettings, loadSettings, saveSettings, clearSettings } from '../storage';
+import { canUseOllama, getDefaultProvider } from '../../environment';
+
+beforeEach(() => {
+  localStorage.clear();
+  // Reset mocks to the "local" defaults before each test
+  vi.mocked(canUseOllama).mockReturnValue(true);
+  vi.mocked(getDefaultProvider).mockReturnValue('ollama');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// getDefaultSettings
+// ---------------------------------------------------------------------------
+describe('getDefaultSettings', () => {
+  it('returns correct Ollama defaults', () => {
+    const s = getDefaultSettings('ollama');
+    expect(s.provider).toBe('ollama');
+    if (s.provider === 'ollama') {
+      expect(s.baseUrl).toBe('http://localhost:11434/v1/');
+      expect(s.model).toBe(PROVIDER_CONFIGS.ollama.defaultModel);
+      expect(s.timeout).toBe(DEFAULT_TIMEOUT);
+    }
+  });
+
+  it('returns correct groq-free defaults', () => {
+    const s = getDefaultSettings('groq-free');
+    expect(s.provider).toBe('groq-free');
+    if (s.provider === 'groq-free') {
+      expect(s.mode).toBe('free-tier');
+      expect(s.model).toBe(PROVIDER_CONFIGS['groq-free'].defaultModel);
+      expect(s.timeout).toBe(DEFAULT_TIMEOUT);
+    }
+  });
+
+  it('returns correct groq defaults with empty apiKey', () => {
+    const s = getDefaultSettings('groq');
+    expect(s.provider).toBe('groq');
+    if (s.provider === 'groq') {
+      expect(s.apiKey).toBe('');
+      expect(s.model).toBe(PROVIDER_CONFIGS.groq.defaultModel);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSettings — no stored data
+// ---------------------------------------------------------------------------
+describe('loadSettings — no stored data', () => {
+  it('returns ollama defaults in a local environment', () => {
+    vi.mocked(canUseOllama).mockReturnValue(true);
+    vi.mocked(getDefaultProvider).mockReturnValue('ollama');
+    const s = loadSettings();
+    expect(s.provider).toBe('ollama');
+  });
+
+  it('returns groq-free defaults in a deployed environment', () => {
+    vi.mocked(canUseOllama).mockReturnValue(false);
+    vi.mocked(getDefaultProvider).mockReturnValue('groq-free');
+    const s = loadSettings();
+    expect(s.provider).toBe('groq-free');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveSettings / loadSettings round-trip
+// ---------------------------------------------------------------------------
+describe('saveSettings / loadSettings round-trip', () => {
+  it('persists and restores groq-free settings', () => {
+    const settings = getDefaultSettings('groq-free');
+    saveSettings(settings);
+    const loaded = loadSettings();
+    expect(loaded.provider).toBe('groq-free');
+    expect(loaded.model).toBe(settings.model);
+  });
+
+  it('persists and restores groq settings including the apiKey', () => {
+    const settings = { ...getDefaultSettings('groq'), apiKey: 'gsk_test_abc123' } as const;
+    saveSettings(settings);
+    const loaded = loadSettings();
+    expect(loaded.provider).toBe('groq');
+    if (loaded.provider === 'groq') {
+      expect(loaded.apiKey).toBe('gsk_test_abc123');
+    }
+  });
+
+  it('fills missing fields from defaults on load', () => {
+    // Save an incomplete settings object (simulating an older stored version)
+    localStorage.setItem('llm_settings', JSON.stringify({ provider: 'groq', apiKey: 'gsk_x' }));
+    const loaded = loadSettings();
+    expect(loaded.provider).toBe('groq');
+    if (loaded.provider === 'groq') {
+      // timeout should be filled from defaults
+      expect(loaded.timeout).toBe(DEFAULT_TIMEOUT);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSettings — model validation
+// ---------------------------------------------------------------------------
+describe('loadSettings — model validation', () => {
+  it('replaces a stored model that is no longer in suggestedModels with the provider default', () => {
+    const settings = { ...getDefaultSettings('groq-free'), model: 'gpt-5-turbo-ultra-deprecated' };
+    saveSettings(settings);
+    const loaded = loadSettings();
+    expect(loaded.model).toBe(PROVIDER_CONFIGS['groq-free'].defaultModel);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSettings — Ollama on deployed site
+// ---------------------------------------------------------------------------
+describe('loadSettings — Ollama on deployed site', () => {
+  it('switches to groq-free when ollama is stored but site is deployed', () => {
+    saveSettings(getDefaultSettings('ollama'));
+    vi.mocked(canUseOllama).mockReturnValue(false);
+    vi.mocked(getDefaultProvider).mockReturnValue('groq-free');
+    const loaded = loadSettings();
+    expect(loaded.provider).toBe('groq-free');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSettings — legacy migration
+// ---------------------------------------------------------------------------
+describe('loadSettings — legacy migration', () => {
+  it('migrates ollama_settings to llm_settings and removes the legacy key', () => {
+    const legacy = {
+      baseUrl: 'http://localhost:11434/v1/',
+      model: 'llama3.2:latest',
+      timeout: DEFAULT_TIMEOUT,
+    };
+    localStorage.setItem('ollama_settings', JSON.stringify(legacy));
+
+    const loaded = loadSettings();
+    expect(loaded.provider).toBe('ollama');
+    if (loaded.provider === 'ollama') {
+      expect(loaded.baseUrl).toBe(legacy.baseUrl);
+    }
+
+    // Legacy key removed, new key written
+    expect(localStorage.getItem('ollama_settings')).toBeNull();
+    expect(localStorage.getItem('llm_settings')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearSettings
+// ---------------------------------------------------------------------------
+describe('clearSettings', () => {
+  it('removes llm_settings from localStorage', () => {
+    saveSettings(getDefaultSettings('groq-free'));
+    expect(localStorage.getItem('llm_settings')).not.toBeNull();
+    clearSettings();
+    expect(localStorage.getItem('llm_settings')).toBeNull();
+  });
+
+  it('also removes the legacy ollama_settings key', () => {
+    localStorage.setItem('ollama_settings', JSON.stringify({ model: 'llama3.2:latest' }));
+    clearSettings();
+    expect(localStorage.getItem('ollama_settings')).toBeNull();
+  });
+});

--- a/src/utils/llm/client.ts
+++ b/src/utils/llm/client.ts
@@ -98,13 +98,18 @@ export function getCurrentModel(settings?: LLMSettings): string {
 export function formatLLMError(error: any, provider?: string): string {
   const errorMessage = error?.message || String(error);
   const statusCode: number | undefined = typeof error?.status === 'number' ? error.status : undefined;
-  const withStatus = (msg: string) => statusCode !== undefined ? `${msg} (HTTP ${statusCode})` : msg;
+  const errorCode: string | null | undefined = error?.code || null;
+  const withCode = (msg: string): string => {
+    if (errorCode) return `${msg} [${errorCode}]`;
+    if (statusCode !== undefined) return `${msg} [HTTP ${statusCode}]`;
+    return `${msg} [no error code provided]`;
+  };
   const activeProvider = provider || loadSettings().provider;
 
   // Quota limit messages are already user-friendly — pass through as-is
-  // (these come from plain Error objects with no .status)
+  // (these come from plain Error objects with no .status or .code)
   if (errorMessage.includes('shared AI service has')) {
-    return errorMessage;
+    return `${errorMessage} [no error code provided]`;
   }
 
   const isFreeTier = activeProvider === 'groq-free';
@@ -113,62 +118,62 @@ export function formatLLMError(error: any, provider?: string): string {
   // Connection errors
   if (errorMessage.includes('ECONNREFUSED') || errorMessage.includes('Failed to fetch')) {
     if (activeProvider === 'ollama') {
-      return withStatus('Cannot connect to Ollama server. Please ensure Ollama is running on your machine.');
+      return withCode('Cannot connect to Ollama server. Please ensure Ollama is running on your machine.');
     }
-    return withStatus('Couldn\'t reach the AI service. Please check your internet connection and try again.');
+    return withCode('Couldn\'t reach the AI service. Please check your internet connection and try again.');
   }
 
   // API key errors
   if (errorMessage.includes('API key') || errorMessage.includes('apiKey') || errorMessage.includes('401')) {
     if (isGroq) {
-      return withStatus('Your Groq API key was rejected. Please check it in Settings and try again.');
+      return withCode('Your Groq API key was rejected. Please check it in Settings and try again.');
     }
     if (isFreeTier) {
-      return withStatus('The AI service credentials are misconfigured. Please contact the developer.');
+      return withCode('The AI service credentials are misconfigured. Please contact the developer.');
     }
-    return withStatus(`Invalid or missing API key. Please check your ${activeProvider.toUpperCase()} API key in Settings.`);
+    return withCode(`Invalid or missing API key. Please check your ${activeProvider.toUpperCase()} API key in Settings.`);
   }
 
   // Model not found
   if (errorMessage.includes('404') || errorMessage.includes('not found')) {
     if (activeProvider === 'ollama') {
-      return withStatus('Model not found. Please pull the model using: ollama pull <model-name>');
+      return withCode('Model not found. Please pull the model using: ollama pull <model-name>');
     }
     if (isFreeTier || isGroq) {
-      return withStatus('The requested AI model is unavailable right now. Please try again shortly.');
+      return withCode('The requested AI model is unavailable right now. Please try again shortly.');
     }
-    return withStatus('Model not found. Please check your model name in Settings.');
+    return withCode('Model not found. Please check your model name in Settings.');
   }
 
   // Timeout errors
   if (errorMessage.includes('timeout') || errorMessage.includes('aborted')) {
     if (isFreeTier || isGroq) {
-      return withStatus('The AI service took too long to respond. Please try again in a moment.');
+      return withCode('The AI service took too long to respond. Please try again in a moment.');
     }
-    return withStatus('Request timeout. The server took too long to respond. Try increasing timeout in Settings.');
+    return withCode('Request timeout. The server took too long to respond. Try increasing timeout in Settings.');
   }
 
   // Rate limit errors
   if (errorMessage.includes('429') || errorMessage.includes('rate limit') || errorMessage.includes('at capacity')) {
     if (isGroq) {
-      return withStatus('You\'ve hit your personal Groq rate limit. Please wait a moment and try again.');
+      return withCode('You\'ve hit your personal Groq rate limit. Please wait a moment and try again.');
     }
     if (isFreeTier) {
-      return withStatus('This shared AI service is currently at capacity — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.');
+      return withCode('This shared AI service is currently at capacity — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.');
     }
-    return withStatus('Rate limit exceeded. Please wait a moment before trying again.');
+    return withCode('Rate limit exceeded. Please wait a moment before trying again.');
   }
 
   // Server errors
   if (errorMessage.includes('500') || errorMessage.includes('502') || errorMessage.includes('503') || errorMessage.includes('unavailable')) {
     if (isFreeTier || isGroq) {
-      return withStatus('The AI service is temporarily unavailable. Please try again in a few minutes.');
+      return withCode('The AI service is temporarily unavailable. Please try again in a few minutes.');
     }
   }
 
   // Generic error — keep Ollama messages technical for developers, soften others
   if (isFreeTier || isGroq) {
-    return withStatus('The AI service encountered an unexpected problem. Please try again shortly.');
+    return withCode('The AI service encountered an unexpected problem. Please try again shortly.');
   }
   return `Error from ${activeProvider.toUpperCase()}: ${errorMessage}`;
 }


### PR DESCRIPTION
- llm-proxy: humanizeGroqError now returns { message, code } instead of a
  plain string, passing Groq's error.code through to the client in the
  standard OpenAI error-object format ({ error: { message, code } }).
  The internal proxy catch-block also adopts this shape with code: null.
- client: replace withStatus() with withCode() which always appends
  something — Groq's error code if present, the HTTP status if available,
  or "[no error code provided]" as a last resort. Quota pass-through
  messages also get the "[no error code provided]" suffix.

https://claude.ai/code/session_01Xfpw45wZ7uRmbchUd4FHEe