### PR TITLE
Fix Groq 413 token rate limit error handling

### DIFF
--- a/docs/groq-token-optimization.md
+++ b/docs/groq-token-optimization.md
@@ -1,0 +1,79 @@
+# Context: Groq Token Rate Limit — Follow-up Work
+
+## What was diagnosed and fixed
+
+The app (horary-chat.netlify.app) was consistently showing
+"The AI service encountered an unexpected problem [no error code provided]"
+on every first response from Groq. Root cause confirmed via Netlify function logs:
+
+**Groq returns HTTP 413 with `error.type = "tokens"` and
+`error.code = "rate_limit_exceeded"` for token-per-minute (TPM) rate limits**
+(non-standard — most APIs use 429 for rate limits).
+
+The proxy (`netlify/functions/llm-proxy.ts`) was mapping ALL 413s to
+"Your question is too long" (wrong). The client (`src/utils/llm/client.ts`)
+had no pattern for that message, so it fell through to a generic error handler.
+
+**PR already merged**: Fixed the proxy to detect `error.type === "tokens"` and
+return a proper "token rate limit" message. Fixed the client to handle genuine
+"content too large" 413s too.
+
+## Why the error happens
+
+The initial horary reading (`generateHoraryReading` in `src/utils/llm.ts:453`)
+sends very token-heavy requests:
+
+| Component | Approx tokens |
+|-----------|--------------|
+| `horaryBasePrompt` system prompt (`src/prompts/horary-base.md`, 13,035 bytes) | ~3,250 |
+| `formatChartForLLMWithMotion` chart data | ~500–750 |
+| 4-part instruction in user message (llm.ts:474–501) | ~275 |
+| `max_tokens` response budget | 2,600 |
+| **Total per initial reading** | **~6,600–7,000** |
+
+A follow-up ("again") uses `continueHoraryConversation` with `horaryFollowupPrompt`
+(3,551 bytes) + simpler chart + `max_tokens: 1500` → only ~2,700–2,900 tokens.
+That's why retrying always works — it's half the token cost.
+
+On Groq free tier, the TPM window for llama-3.3-70b-versatile is limited.
+One or two initial readings in a session can exhaust the window, causing the
+next initial reading to 413 immediately.
+
+## What still needs doing
+
+### 1. Reduce input tokens on initial reading (highest impact)
+
+- `src/prompts/horary-base.md` is 13,035 bytes (~3,250 tokens) — the dominant cost.
+  Review for verbose or redundant instructions. A 30% trim saves ~1,000 tokens per request.
+- The 4-part instruction text in `src/utils/llm.ts:474–501` (~275 tokens) may overlap
+  with what's already in the system prompt.
+
+### 2. Add automatic retry with backoff on 413 token rate limit
+
+When the proxy receives a 413 with `error.type === "tokens"`, instead of surfacing the
+error to the client, wait and retry the Groq request once. The TPM window resets quickly,
+so the retry succeeds silently — the user never sees the error.
+
+Implementation point: `netlify/functions/llm-proxy.ts` after line 183 (where Groq errors
+are handled). Note: Netlify free-tier function timeout is 10 seconds — a retry delay of
+any meaningful length requires either upgrading to background functions or moving the
+retry to the client side with a loading state.
+
+### 3. (Optional) Log token usage per request
+
+Add `console.log('tokens used:', data?.usage?.total_tokens)` in `llm-proxy.ts` after
+a successful Groq response (around line 200). This gives visibility into actual TPM
+consumption and helps tune limits.
+
+## Key files
+
+- `netlify/functions/llm-proxy.ts` — proxy, error handling, retry would go here
+- `src/prompts/horary-base.md` — system prompt to review for verbosity
+- `src/utils/llm.ts:453–525` — `generateHoraryReading`, instruction text at lines 474–501
+- `src/utils/llm/client.ts` — client-side error formatting (already fixed)
+- `src/utils/llm/freeTier.ts` — client-side quota tracking (separate from Groq TPM)
+
+## Stack
+
+Vue 3 + TypeScript + Vite, Netlify serverless functions, Groq API (openai-compatible),
+openai SDK v5 (`openai@^5.3.0`). Tests: `npm run test:run`. Build: `npm run build`.

--- a/netlify/functions/llm-proxy.ts
+++ b/netlify/functions/llm-proxy.ts
@@ -27,6 +27,13 @@ function humanizeGroqError(status: number, isUserKey: boolean, error?: { type?: 
     return { message: 'The requested AI model is unavailable right now. Please try again shortly.', code };
   }
   if (status === 413) {
+    if (errorType === 'tokens' || errorType.includes('token') || error?.code === 'rate_limit_exceeded') {
+      // Groq uses 413 (not 429) for token-per-minute rate limits
+      if (isUserKey) {
+        return { message: "You've hit your personal Groq token rate limit. Please wait a moment and try again.", code };
+      }
+      return { message: 'This shared AI service has used a lot of capacity recently — you\'re not the only one using it! Please wait a moment and try again, or add your own free Groq API key in Settings → LLM Provider.', code };
+    }
     return { message: 'Your question is too long for the AI to process. Please shorten it and try again.', code };
   }
   if (status === 422) {

--- a/src/utils/llm/client.ts
+++ b/src/utils/llm/client.ts
@@ -171,6 +171,11 @@ export function formatLLMError(error: any, provider?: string): string {
     }
   }
 
+  // Content too large — genuine 413 (not a token rate limit)
+  if (errorMessage.includes('too long') || errorMessage.includes('shorten')) {
+    return withCode('Your question is too long for the AI to process. Please try a shorter question.');
+  }
+
   // Generic error — keep Ollama messages technical for developers, soften others
   if (isFreeTier || isGroq) {
     return withCode('The AI service encountered an unexpected problem. Please try again shortly.');


### PR DESCRIPTION
## Summary

- Added detection for Groq's non-standard HTTP 413 token-per-minute (TPM) rate limit errors in the proxy (`llm-proxy.ts`)
- Distinguish between genuine "content too large" 413s and token rate limit 413s by checking `error.type === 'tokens'` or `error.code === 'rate_limit_exceeded'`
- Return appropriate user-facing messages for each case: rate limit vs. content length
- Added client-side pattern matching in `client.ts` to handle "too long" messages from genuine content-size 413s
- Added comprehensive documentation (`groq-token-optimization.md`) explaining the root cause, token costs of initial horary readings (~6,600–7,000 tokens), and follow-up work needed (prompt optimization, automatic retry with backoff, token usage logging)

## Context

The app was showing generic "unexpected problem" errors on first Groq responses due to token rate limits. Groq returns HTTP 413 (not the standard 429) when TPM limits are exceeded, and the proxy was incorrectly mapping all 413s to "your question is too long." This fix properly identifies and communicates rate limit errors while preserving handling for actual oversized requests.

## Test plan

- [ ] `npm run test:run` passes
- [ ] `npm run build` passes
- [ ] Manual: Trigger a Groq 413 with `error.type === "tokens"` and verify the user sees the rate limit message (not "too long")
- [ ] Manual: Verify genuine content-too-large 413s still show the appropriate message

## Notes

This is a follow-up to a previously merged fix. The documentation outlines three areas for future optimization:
1. Reduce `horary-base.md` prompt verbosity (~3,250 tokens, highest impact)
2. Add automatic retry with backoff in the proxy (requires handling 10s Netlify timeout)
3. Add token usage logging for visibility into TPM consumption

No breaking changes; error messages are improved but behavior is the same.

https://claude.ai/code/session_01JXkCWxFgdvc5z3kavCzaD7