### PR TITLE
Reduce token usage and add silent retry on Groq TPM rate limit

### DIFF
--- a/netlify/functions/llm-proxy.ts
+++ b/netlify/functions/llm-proxy.ts
@@ -204,6 +204,8 @@ export const handler: Handler = async (event: HandlerEvent) => {
       };
     }
 
+    console.log('tokens used:', data?.usage?.total_tokens);
+
     // Return successful response
     return {
       statusCode: 200,

--- a/src/prompts/horary-base.md
+++ b/src/prompts/horary-base.md
@@ -30,9 +30,6 @@ Relationship: 1st=querent, 7th=partner, 5th=romance | Job: 1st=querent, 10th=emp
 **House Identification:**
 The chart data includes a "### Relevant House Context" section pre-analyzed for this specific question. It lists the primary and supporting houses with their full traditional meanings, topics, and derivative house notes. Use that section as your primary reference for which house(s) govern the quesited.
 
-Quick reference (full detail is in the chart data):
-1st Querent/body | 2nd Money/possessions | 3rd Siblings/communication/vehicles | 4th Home/father/real estate | 5th Romance/children/gambling | 6th Illness/employees/pets | 7th Partner/opponents/contracts | 8th Death/inheritance/shared resources | 9th Long journeys/law/higher education | 10th Career/employer/reputation | 11th Friends/hopes/groups | 12th Hidden enemies/confinement/self-undoing
-
 ### 3. Essential Dignities (Planet's Condition in Sign)
 **Dignity scores provided:**
 - **Ruler/Domicile** (+5): Very strong, acts freely
@@ -68,14 +65,6 @@ Quick reference (full detail is in the chart data):
   - Moon has no essential dignity (0), but strong dispositor helps
   - Interpretation: "Moon neutral, but well-supported by capable Mercury"
 
-<!-- [ADJUSTABLE: May be condensed for smaller models] -->
-**Example with Venus in Pisces (Common Confusion):**
-- Venus in Pisces = EXALTED (+4) = Strong planet
-- Jupiter rules Pisces = Jupiter is Venus's dispositor
-- Venus's exaltation does NOT depend on Jupiter's condition
-- If Jupiter is also strong → Venus has strong support too
-- If Jupiter is weak → Venus is still exalted, just less supported
-
 **Key Rule:** Essential dignity (the planet's own strength) comes FIRST. Dispositor support is a bonus or limitation on top of that baseline.
 
 **For Part of Fortune:** Strong PoF dispositor = querent HAS capacity to succeed. Weak = LACKS resources.
@@ -99,13 +88,6 @@ Quick reference (full detail is in the chart data):
 1. **Which houses** planets rule
 2. **What they represent** in the question
 3. The **relationship dynamic**
-
-<!-- [ADJUSTABLE: May be condensed for smaller models] -->
-**CORRECT Example:**
-"Sun rules 1st (you) and Saturn rules 7th (them). Sun in Leo (own sign), Saturn in Aquarius (own sign). No mutual reception = both operate independently, not disposed to help each other."
-
-**WRONG Example:**
-"Sun in Leo, Saturn in Aquarius. No mutual reception." ❌ (Doesn't say WHO they represent!)
 
 **Reception Types:**
 - **Mutual**: In each other's signs → favorably disposed
@@ -157,8 +139,6 @@ The chart data includes ⏱ Timing sections on applying aspects and aspect orbs 
 2. Identify significators
 3. Assess dignity (are significators strong or weak?)
    - Check the dignity SCORE first (4-7 = strong, -4 to -5 = weak)
-   - Venus in Pisces? Score +4 = EXALTED = Strong
-   - Mars in Capricorn? Score +4 = EXALTED = Strong
 4. Check Part of Fortune (dispositor strong?)
 5. Check aspects (applying/separating?)
 6. Check prohibitions/frustrations

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -471,36 +471,11 @@ export const generateHoraryReading = async (
 
     const prompt = `${formattedChart}
 
-Please provide a traditional horary reading for this question. All chart data including significators, aspects between them, house rulers, and potential prohibitions/frustrations has been provided above.
+Please provide a traditional horary reading for this question using the chart data above.
 
-**CRITICAL: Follow the three-part response structure:**
+Begin your response immediately with "## Overall Judgment" — no preamble. End with "## Suggested Follow-up Questions" (3–4 short, specific questions drawn directly from this chart, formatted as a bulleted list).`;
 
-**Part 1 - Overall Judgment (Plain English):**
-Start with your judgment in clear, accessible language that anyone can understand. NO astrological jargon. Give the answer, explain why, include timing. This should make sense to someone who knows nothing about astrology.
-
-**Part 2 - Detailed Astrological Analysis (Technical):**
-Then provide the technical analysis using proper astrological terminology. ALWAYS reference house placements and rulerships throughout this section.
-
-**Part 3 - Summary (Plain English):**
-Close with a brief, friendly wrap-up in 2–3 sentences. No jargon. Reinforce the verdict and leave the querent with a clear, grounded takeaway.
-
-**Part 4 - Suggested Follow-up Questions:**
-End with 3–4 short, specific follow-up questions the querent might want to explore next, drawn directly from this chart (e.g. timing, a specific planet's role, a derivative house topic, reception, or an unexplored factor). Format as a simple bulleted list under the heading "## Suggested Follow-up Questions". Each question should be concise and self-contained — something a user could click and send as-is.
-
-**Judgment process to follow internally:**
-1. Check radicality (chart validity - Ascendant degree, Moon VOC status)
-2. Review significators (1st and 7th house rulers in Significator Analysis section)
-3. Assess dignity (examine essential dignity scores - Venus in Pisces = +4 exalted, etc.)
-4. Analyze house placements (which houses do key planets occupy and rule?)
-5. Check aspects (applying or separating? Check "Aspects Between Significators")
-6. Check prohibitions/frustrations (retrograde warnings, third planet interference)
-7. Consider reception (how do significators receive each other by dignity?)
-8. Moon's role (review Moon's last and next aspects)
-9. Provide timing (based on aspect orb, sign type, house placement)
-
-Begin your response immediately with "## Overall Judgment" — no preamble. End with "## Suggested Follow-up Questions".`;
-
-    const response = await openai.chat.completions.create({
+    const makeRequest = () => openai.chat.completions.create({
       model,
       messages: [
         { role: "system", content: systemPrompt },
@@ -509,6 +484,20 @@ Begin your response immediately with "## Overall Judgment" — no preamble. End 
       temperature: 0.7,
       max_tokens: 2600,
     });
+
+    let response;
+    try {
+      response = await makeRequest();
+    } catch (apiError: any) {
+      // Groq uses 413 (not 429) for token-per-minute rate limits.
+      // The TPM window resets quickly, so retry once after a short delay.
+      if (apiError?.status === 413 && apiError?.code === 'rate_limit_exceeded') {
+        await new Promise(r => setTimeout(r, 8000));
+        response = await makeRequest();
+      } else {
+        throw apiError;
+      }
+    }
 
     // Record usage for free tier
     if (settings.provider === 'groq-free') {


### PR DESCRIPTION
- Trim horary-base.md: remove three [ADJUSTABLE] example blocks and a
  duplicate house quick-reference list (~200-300 tokens saved per request)
- Replace verbose 4-part user message instruction in llm.ts with a short
  anchor-only prompt (~220 tokens saved); system prompt already carries
  the full response structure and judgment checklist
- Add client-side retry in generateHoraryReading: on a 413
  rate_limit_exceeded error, wait 8s and retry once silently so users
  never see the TPM error (Netlify 10s timeout makes server-side retry
  too risky)
- Log token usage in llm-proxy.ts after each successful Groq response

https://claude.ai/code/session_014V5wUhvCNhRjqz8QCYWiuT