### PR TITLE
fix dark mode: purge stale SW cache, sync composable from DOM, fix theme-color

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" content="#FFD700" />
+    <meta name="theme-color" content="#b8690a" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#161a12" media="(prefers-color-scheme: dark)" />
     <script>
       (function () {
         var stored = localStorage.getItem('darkMode');

--- a/src/composables/useDarkMode.ts
+++ b/src/composables/useDarkMode.ts
@@ -1,22 +1,8 @@
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch } from 'vue';
 
-const isDark = ref(false);
+const isDark = ref(document.documentElement.classList.contains('dark'));
 
 export function useDarkMode() {
-  onMounted(() => {
-    // Check localStorage or system preference
-    const stored = localStorage.getItem('darkMode');
-    if (stored !== null) {
-      isDark.value = stored === 'true';
-    } else {
-      // Check system preference
-      isDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    }
-
-    // Apply initial theme
-    applyTheme(isDark.value);
-  });
-
   watch(isDark, (newValue) => {
     localStorage.setItem('darkMode', String(newValue));
     applyTheme(newValue);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         ],
       },
       workbox: {
+        cleanupOutdatedCaches: true,
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
         runtimeCaching: [
           {


### PR DESCRIPTION
- vite.config.ts: add cleanupOutdatedCaches: true to Workbox so old
  precached CSS is deleted when a new service worker activates, preventing
  the blue/slate flash caused by stale CSS missing :root.dark variables
- useDarkMode.ts: initialize isDark directly from
  document.documentElement.classList rather than re-reading localStorage
  in onMounted — the inline script in index.html already set the DOM
  state correctly, so this removes redundancy and eliminates the FOUC
  window where composable state disagreed with the DOM
- index.html: replace static #FFD700 theme-color with media-query-aware
  variants (amber for light, near-black for dark) so the browser chrome
  matches the active theme on iOS/Android

https://claude.ai/code/session_011Dcy5oVyvF6zhe1cNXbcDF